### PR TITLE
fix(cli): shared set parsing for npm/yarn install options

### DIFF
--- a/bin/npq-hero.js
+++ b/bin/npq-hero.js
@@ -10,21 +10,21 @@ const inquirer = require('inquirer')
 const yargs = require('yargs')
 const pkgMgr = require('../lib/packageManager')
 const Marshall = require('../lib/marshall')
+const cliCommons = require('../lib/cliCommons')
 
 const PACKAGE_MANAGER_TOOL = process.env.NPQ_PKG_MGR
 
 const cli = yargs
-  .command({
-    command: 'install [package...]',
-    aliases: ['i', 'add'],
-    desc: 'install a package'
-  })
+  .options(cliCommons.getOptions())
+  .command(cliCommons.getInstallCommand())
   .help(false)
   .version(false).argv
 
 const marshall = new Marshall({
   pkgs: cli.package
 })
+
+console.log(cli)
 
 marshall
   .process()

--- a/bin/npq.js
+++ b/bin/npq.js
@@ -14,6 +14,8 @@ const marshall = new Marshall({
   pkgs: cli.package
 })
 
+console.log(cli)
+
 marshall
   .process()
   .then(result => {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,17 +1,15 @@
 'use strict'
 
 const yargs = require('yargs')
+const cliCommons = require('./cliCommons')
 
 const argv = yargs
   .version()
   .usage('Usage: npq install <package> [options]')
   .help('help')
   .alias('help', 'h')
-  .command({
-    command: 'install [package...]',
-    aliases: ['i', 'add'],
-    desc: 'install a package'
-  })
+  .options(cliCommons.getOptions())
+  .command(cliCommons.getInstallCommand())
   .command({
     command: '--packageManager [packageManager]',
     aliases: ['--pkgMgr'],

--- a/lib/cliCommons.js
+++ b/lib/cliCommons.js
@@ -1,0 +1,48 @@
+class cliCommons {
+  static getInstallCommand() {
+    return {
+      command: 'install [package...]',
+      aliases: ['i', 'add'],
+      desc: 'install a package'
+    }
+  }
+
+  static getOptions() {
+    return {
+      P: {
+        alias: ['save-prod', 'peer'],
+        type: 'boolean'
+      },
+      D: {
+        alias: ['save-dev', 'dev'],
+        type: 'boolean'
+      },
+      O: {
+        alias: ['save-optional', 'optional'],
+        type: 'boolean'
+      },
+      E: {
+        alias: ['save-exact', 'exact'],
+        type: 'boolean'
+      },
+      B: {
+        alias: 'save-bundle',
+        type: 'boolean'
+      },
+      T: {
+        alias: 'tilde',
+        type: 'boolean'
+      },
+      nosave: {
+        alias: 'no-save',
+        type: 'boolean'
+      },
+      'dry-run': {
+        alias: 'dry-run',
+        type: 'boolean'
+      }
+    }
+  }
+}
+
+module.exports = cliCommons

--- a/lib/cliCommons.js
+++ b/lib/cliCommons.js
@@ -1,5 +1,5 @@
 class cliCommons {
-  static getInstallCommand() {
+  static getInstallCommand () {
     return {
       command: 'install [package...]',
       aliases: ['i', 'add'],
@@ -7,7 +7,7 @@ class cliCommons {
     }
   }
 
-  static getOptions() {
+  static getOptions () {
     return {
       P: {
         alias: ['save-prod', 'peer'],


### PR DESCRIPTION
Fixes #6 

- [x] Adds a shared cli util for options/commands setting between npq and npq-hero
- [x] Adds command line options to recognise npm/yarn specific yarn install options