### PR TITLE
build(package.json): remove broken doc scripts and their vulnerable deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,6 @@
     "test:watch": "jest --watch",
     "coverage:view": "opn coverage/lcov-report/index.html",
     "commit": "git-cz",
-    "docs": "yarn run docs:code && yarn run docs:api",
-    "docs:api": "doxdox *.js --layout bootstrap --output docs/index.html",
-    "docs:code": "docco *.js --output docs/code",
     "semantic-release": "semantic-release"
   },
   "author": {


### PR DESCRIPTION
The docs script in package.json currently fails because the file input path used contains no files.
The library doxdox contains vulnerable dependencies and appears to be abandon by its maintainer.

## Description
Removed the docs, docs:api, and docs:code npm scripts. They don't work, the packages they use contain vulnerabilities and doxdox appears to be abandon.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #74 

## Motivation and Context
The docs script in package.json currently fails because the file input path used contains no files.
The library doxdox contains vulnerable dependencies and appears to be abandon by its maintainer.

## How Has This Been Tested?
Unit tests, commit/push hooks and code coverage still pass.
