### PR TITLE
feat(install scripts): add automatic shell alias installation

### DIFF
--- a/__tests__/scripts.test.js
+++ b/__tests__/scripts.test.js
@@ -1,0 +1,96 @@
+const fs = require('fs')
+const inquirer = require('inquirer')
+
+const postinstall = require('../scripts/postinstall').testable
+const preuninstall = require('../scripts/preuninstall').testable
+const helpers = require('../scripts/scriptHelpers')
+
+const TEST_PROFILE_PATH = '/tmp/.npq_test_profile'
+const TEST_ALIAS = 'alias npm="npq-hero"'
+inquirer.prompt = jest.fn().mockResolvedValue({ install: true })
+
+let mockGetShellConfig
+
+beforeEach(() => {
+  mockGetShellConfig = jest.spyOn(helpers, 'getShellConfig').mockImplementation(() => ({ name: 'testShell', profilePath: TEST_PROFILE_PATH, aliases: TEST_ALIAS }))
+})
+
+afterEach(async () => {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    await fs.promises.unlink(TEST_PROFILE_PATH)
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      return
+    }
+    throw err
+  }
+})
+
+test('postinstall stops when detecting unknown shell', async () => {
+  mockGetShellConfig.mockRestore()
+  process.env.SHELL = '/usr/bin/fakeshell'
+
+  await postinstall.runPostInstall()
+  const containsAlias = await helpers.fileContains(TEST_PROFILE_PATH, TEST_ALIAS)
+  expect(containsAlias).toBe(false)
+})
+
+test('postinstall script adds aliases', async () => {
+  await postinstall.runPostInstall()
+
+  const containsAlias = await helpers.fileContains(TEST_PROFILE_PATH, TEST_ALIAS)
+  expect(containsAlias).toBe(true)
+})
+
+test('postinstall script does not create duplicate aliases', async () => {
+  await postinstall.runPostInstall()
+  await postinstall.runPostInstall()
+
+  const containsAlias = await helpers.fileContains(TEST_PROFILE_PATH, TEST_ALIAS)
+  const containsDoubleAlias = await helpers.fileContains(TEST_PROFILE_PATH, `${TEST_ALIAS}${TEST_ALIAS}`)
+  expect(containsAlias).toBe(true)
+  expect(containsDoubleAlias).toBe(false)
+})
+
+test('uninstall script removes aliases', async () => {
+  await postinstall.runPostInstall()
+  await preuninstall.runPreUninstall()
+
+  const containsAlias = await helpers.fileContains(TEST_PROFILE_PATH, TEST_ALIAS)
+  expect(containsAlias).toBe(false)
+})
+
+test('uninstall script does nothing in unknown shell', async () => {
+  await postinstall.runPostInstall()
+
+  mockGetShellConfig.mockRestore()
+  process.env.SHELL = '/usr/bin/fakeshell'
+
+  await preuninstall.runPreUninstall()
+  const containsAlias = await helpers.fileContains(TEST_PROFILE_PATH, TEST_ALIAS)
+  expect(containsAlias).toBe(true)
+})
+
+test('uninstall handles empty profile', async () => {
+  await preuninstall.runPreUninstall()
+
+  const profileExists = await fs.promises.access(TEST_PROFILE_PATH, fs.constants.F_OK).then(() => true).catch(() => false)
+  expect(profileExists).toBe(false)
+})
+
+describe('getShellConfig', () => {
+  test('detects bash', () => {
+    mockGetShellConfig.mockRestore()
+    process.env.SHELL = '/bin/bash'
+    const { name } = helpers.getShellConfig()
+    expect(name).toBe('bash')
+  })
+
+  test('detects zsh', () => {
+    mockGetShellConfig.mockRestore()
+    process.env.SHELL = '/usr/bin/zsh'
+    const { name } = helpers.getShellConfig()
+    expect(name).toBe('zsh')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "docs:code": "docco *.js --output docs/code",
     "semantic-release": "semantic-release",
     "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "prepublish": "npm run snyk-protect",
+    "postinstall": "node scripts/postinstall.js",
+    "preuninstall": "node scripts/preuninstall.js"
   },
   "author": {
     "name": "Liran Tal",
@@ -63,6 +65,12 @@
         "functions": 90,
         "lines": 90,
         "statements": 90
+      },
+      "scripts/*": {
+        "branches": 60,
+        "functions": 90,
+        "lines": 80,
+        "statements": 80
       }
     },
     "testPathIgnorePatterns": [
@@ -136,7 +144,14 @@
       "node/no-unsupported-features/node-builtins": [
         "error",
         {
-          "version": ">=6.0.0",
+          "version": ">=10.1.0",
+          "ignores": []
+        }
+      ],
+      "node/no-unsupported-features/es-syntax": [
+        "error",
+        {
+          "version": ">=10.1.0",
           "ignores": []
         }
       ]

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -18,10 +18,12 @@ const runPostInstall = async () => {
   }
 
   try {
+    console.log('Thank you for installing npq! We want to help you make conscious decisions before installing potentially dangerous packages.')
+    console.log('To do that, we can alias npm and yarn to npq, so that e.g. `npm install <package>` will first use npq to verify the package and prompt you if it finds any issues.')
     const answers = await inquirer.prompt([{
       type: 'confirm',
       name: 'install',
-      message: `📎 Looks like you're using ${shellConfig.name}. Do you want to add aliases for npm and yarn?`
+      message: `Do you want to add ${shellConfig.name} aliases for npm and yarn?`
     }])
     if (answers['install']) {
       // eslint-disable-next-line security/detect-non-literal-fs-filename

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,46 @@
+const fs = require('fs')
+const chalk = require('chalk')
+const inquirer = require('inquirer')
+
+const helpers = require('./scriptHelpers')
+
+const runPostInstall = async () => {
+  const shellConfig = helpers.getShellConfig()
+  if (!shellConfig) {
+    console.log('Could not detect your shell; please add aliases for npq manually.')
+    return
+  }
+
+  // Postinstall scripts also run when e.g. adding a new dependency,
+  // so don't prompt the user if they've already installed aliases
+  if (await helpers.fileContains(shellConfig.profilePath, shellConfig.aliases)) {
+    return
+  }
+
+  try {
+    const answers = await inquirer.prompt([{
+      type: 'confirm',
+      name: 'install',
+      message: `📎 Looks like you're using ${shellConfig.name}. Do you want to add aliases for npm and yarn?`
+    }])
+    if (answers['install']) {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      await fs.promises.appendFile(shellConfig.profilePath, shellConfig.aliases)
+      console.log(chalk.green('✔'), 'Reload your shell profile to use npq!')
+    }
+  } catch (err) {
+    if (err.isTtyError) {
+      // Could not render inquirer prompt; abort auto-install
+      return
+    }
+    console.error(chalk.red('Failed to add aliases: '), err)
+  }
+}
+
+module.exports.testable = {
+  runPostInstall
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  runPostInstall()
+}

--- a/scripts/preuninstall.js
+++ b/scripts/preuninstall.js
@@ -1,0 +1,19 @@
+const helpers = require('./scriptHelpers')
+
+const runPreUninstall = async () => {
+  const shellConfig = helpers.getShellConfig()
+  if (!shellConfig) {
+    return
+  }
+
+  const { profilePath, aliases } = shellConfig
+  await helpers.removeFromFile(profilePath, aliases)
+}
+
+module.exports.testable = {
+  runPreUninstall
+}
+
+if (process.env.NODE_ENV !== 'test') {
+  runPreUninstall()
+}

--- a/scripts/scriptHelpers.js
+++ b/scripts/scriptHelpers.js
@@ -43,7 +43,7 @@ module.exports.removeFromFile = async (profilePath, aliases) => {
 const getProfile = async (profilePath) => {
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
-    const profileData = await fs.promises.readFile(profilePath, 'utf-8')
+    const profileData = await fs.promises.readFile(profilePath, 'utf8')
     return profileData
   } catch (err) {
     if (err && err.code === 'ENOENT') {

--- a/scripts/scriptHelpers.js
+++ b/scripts/scriptHelpers.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const os = require('os')
+
+const BASH_ZSH_ALIASES = '\nalias npm="npq-hero"\nalias yarn="NPQ_PKG_MGR=yarn npq-hero"\n'
+const SHELLS = {
+  'bash': {
+    profilePath: `${os.homedir()}/.bash_profile`,
+    aliases: BASH_ZSH_ALIASES
+  },
+  'zsh': {
+    profilePath: `${os.homedir()}/.zshrc`,
+    aliases: BASH_ZSH_ALIASES
+  }
+}
+const SUPPORTED_SHELLS = Object.keys(SHELLS)
+
+module.exports.getShellConfig = () => {
+  const shellPath = process.env.SHELL
+  if (shellPath) {
+    const shell = shellPath.split('/').pop()
+    if (SUPPORTED_SHELLS.indexOf(shell) > -1) {
+      return { name: shell, ...SHELLS[shell] }
+    }
+  }
+  return null
+}
+
+module.exports.fileContains = async (profilePath, aliases) => {
+  const profileData = await getProfile(profilePath)
+  return !!profileData && profileData.includes(aliases)
+}
+
+module.exports.removeFromFile = async (profilePath, aliases) => {
+  const profileData = await getProfile(profilePath)
+  if (!profileData) {
+    return
+  }
+  const newProfile = profileData.replace(aliases, '')
+  // eslint-disable-next-line security/detect-non-literal-fs-filename
+  await fs.promises.writeFile(profilePath, newProfile)
+}
+
+const getProfile = async (profilePath) => {
+  try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename
+    const profileData = await fs.promises.readFile(profilePath, 'utf-8')
+    return profileData
+  } catch (err) {
+    if (err && err.code === 'ENOENT') {
+
+    } else if (err) {
+      throw err
+    }
+  }
+}


### PR DESCRIPTION
implement #90

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR adds post-install and pre-uninstall scripts to prompt the user to automatically add shell aliases for npq upon installation, and to automatically remove those aliases when uninstalling. Initially just supports bash and zsh.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/lirantal/npq/issues/90

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
> When someone installs npq they would probably want to use it in an integrated manner with npm and yarn by aliasing it. (https://github.com/lirantal/npq/issues/90)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
I've added integration tests for the two scripts, and unit tests for the shell detection code.
I haven't tested an interactive script like this one before, so I'm very happy to hear feedback here -- also on the fact that I couldn't quite get to the 90% coverage. The lines that aren't covered are related to file read/write error handling, and it seems like adding test cases with e.g. files you don't have permission to read will complicate things more than is worth it. But let me know if you disagree!

This has been tested in bash and zsh on my Linux machine.

## Other

I removed Node 8 support to use `fs.promises`, but this isn't strictly necessary and I'm happy to revert to plain `fs` calls if you'd like to keep supporting Node 8.

## Screenshots (if appropriate):
![Screenshot from 2020-10-12 14-25-57](https://user-images.githubusercontent.com/66130243/95751730-eca81c00-0c96-11eb-803c-47d24927a9b0.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
