### PR TITLE
fix(install scripts): don't run install script in yarn

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ safely* - there's no guaranteed safety; a malicious or vulnerable package could 
 npm install -g npq
 ```
 
+*Note: we recommend installing with `npm` rather than `yarn`. That way, `npq` can automatically install shell aliases for you.*
+
 ## Usage
 
 ### Install packages with npq:

--- a/__tests__/scripts.test.js
+++ b/__tests__/scripts.test.js
@@ -47,7 +47,8 @@ test('postinstall script does not run in yarn', async () => {
   const oldExecPath = process.env.npm_execpath
 
   const spy = jest.spyOn(console, 'log')
-  process.env.npm_execpath = '/usr/lib/node_modules/yarn/bin/yarn.js'
+  // pretend that we're running in yarn, whether or not we actually are
+  process.env.npm_execpath = '/example/path/to/yarn.js'
 
   await postinstall.runPostInstall()
   expect(spy).not.toHaveBeenCalled()

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,6 +5,11 @@ const inquirer = require('inquirer')
 const helpers = require('./scriptHelpers')
 
 const runPostInstall = async () => {
+  if (helpers.isRunningInYarn()) {
+    // `yarn add` cannot get stdin input, so we can't run this script there
+    return
+  }
+
   const shellConfig = helpers.getShellConfig()
   if (!shellConfig) {
     console.log('Could not detect your shell; please add aliases for npq manually.')

--- a/scripts/scriptHelpers.js
+++ b/scripts/scriptHelpers.js
@@ -18,7 +18,7 @@ const SUPPORTED_SHELLS = Object.keys(SHELLS)
 module.exports.getShellConfig = () => {
   const shellPath = process.env.SHELL
   if (shellPath) {
-    const shell = shellPath.split('/').pop()
+    const shell = shellPath.split(path.sep).pop().replace('.exe', '')
     if (SUPPORTED_SHELLS.indexOf(shell) > -1) {
       return { name: shell, ...SHELLS[shell] }
     }

--- a/scripts/scriptHelpers.js
+++ b/scripts/scriptHelpers.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const os = require('os')
+const path = require('path')
 
 const BASH_ZSH_ALIASES = '\nalias npm="npq-hero"\nalias yarn="NPQ_PKG_MGR=yarn npq-hero"\n'
 const SHELLS = {
@@ -38,6 +39,12 @@ module.exports.removeFromFile = async (profilePath, aliases) => {
   const newProfile = profileData.replace(aliases, '')
   // eslint-disable-next-line security/detect-non-literal-fs-filename
   await fs.promises.writeFile(profilePath, newProfile)
+}
+
+module.exports.isRunningInYarn = () => {
+  const execPath = process.env['npm_execpath'] || ''
+  const binaryName = execPath.split(path.sep).pop()
+  return binaryName.toLowerCase().includes('yarn')
 }
 
 const getProfile = async (profilePath) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes #154 .

I snuck in an additional fix: shell detection was not working properly in Windows because I had used '/' instead of `path.sep`. That's resolved now, and tested on Windows 10. Let me know if you'd like a separate PR for this instead.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#154 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Installs should work regardless of whether using npm or yarn!

Apologies for causing this bug in the first place, but glad it's fixed now :)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
I added a test verifying that the install script doesn't run in yarn. Of course, the added code in this PR broke several tests when running `yarn test` rather than `npm run test`! I worked around that.

I'm not super happy about this conditional -- it feels too fragile that tests can pass in `npm` but fail in `yarn` without explicitly working around that. However, I can't think of a cleaner way to handle this.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
