### PR TITLE
fix: npq doesn't support the npm alias convention #152 n packages cover

### DIFF
--- a/lib/cliCommons.js
+++ b/lib/cliCommons.js
@@ -7,8 +7,11 @@ class cliCommons {
       aliases: ['i', 'add'],
       desc: 'install a package',
       handler: (argv) => {
-        if (argv && argv.package && argv.package[0]) {
-          argv.package[0] = npa(argv.package[0]).name
+        if (argv && argv.package) {
+          for (let i = 0; i < argv.package.length; i++) {
+            // eslint-disable-next-line security/detect-object-injection
+            argv.package[i] = npa(argv.package[i]).name
+          }
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding support for getting names of n arguments, not just the first argument
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We will still have an issue if we only cover the first argument, that's why we need to cover all arguments example
npq install express jquery2@npm:jquery@2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
