### PR TITLE
fix(marshalls): fix readme/license confusion

### DIFF
--- a/lib/marshalls/license.marshall.js
+++ b/lib/marshalls/license.marshall.js
@@ -16,25 +16,25 @@ class Marshall extends BaseMarshall {
 
   validate (pkg) {
     return this.packageRepoUtils
-      .getReadmeInfo(pkg.packageName)
-      .then(readmeContents => {
+      .getLicenseInfo(pkg.packageName)
+      .then(licenseContents => {
         if (
-          !readmeContents ||
-          readmeContents === 'ERROR: No README data found!'
+          !licenseContents ||
+          licenseContents === 'ERROR: No LICENSE data found!'
         ) {
-          throw new Error('package has no README file available')
+          throw new Error('package has no LICENSE file available')
         }
 
         if (
-          readmeContents &&
-          readmeContents.indexOf('# Security holding package') === 0
+          licenseContents &&
+          licenseContents.indexOf('# Security holding package') === 0
         ) {
           throw new Error(
             'package flagged for security issues and served as place-holder'
           )
         }
 
-        return readmeContents
+        return licenseContents
       })
   }
 }


### PR DESCRIPTION
README was being checked in LICENSE marshalling resulting in duplicate "package has no README file
available" messages

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing erroneous (I suspect copy-pasted) code where functionality conflicted with naming (i.e. `getReadmeInfo` used in `license.marshall.js`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
Existing tests all pass. While there was already a test for `getLicenseInfo`, the method itself was never actually called.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
