### PR TITLE
Replace encodeURIComponent with encodeURI for Snyk URLs

### DIFF
--- a/lib/marshalls/snyk.marshall.js
+++ b/lib/marshalls/snyk.marshall.js
@@ -60,9 +60,7 @@ class Marshall extends BaseMarshall {
   }
 
   getSnykVulnInfoUnauthenticated ({ packageName, packageVersion }) {
-    const url = `${SNYK_TEST_URL}/${encodeURIComponent(
-      packageName
-    )}/${encodeURIComponent(packageVersion)}?type=json`
+    const url = encodeURI(`${SNYK_TEST_URL}/${packageName}/${packageVersion}?type=json`)
 
     return axios
       .get(url)
@@ -85,9 +83,7 @@ class Marshall extends BaseMarshall {
       return this.getSnykVulnInfoUnauthenticated({ packageName, packageVersion })
     }
 
-    const url = `${SNYK_API_URL}/${encodeURIComponent(
-      packageName
-    )}/${encodeURIComponent(packageVersion)}`
+    const url = encodeURI(`${SNYK_API_URL}/${packageName}/${packageVersion}`)
 
     return axios
       .get(url, {


### PR DESCRIPTION
## Description
Replaced the `encodeURIComponent` function used on the package name and the package version to build queried Snyk URLs with `encodeURI` on the whole built URL, to apply changes like "@" –> `%40` and "/" –> `%2F` only on query params that are not part of the URL path.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
Fixes #172.

## Motivation and Context
Solves the `Unable to query vulnerabilities for packages` error when trying to install packages whose name includes characters such as "@" and "/".

## How Has This Been Tested?
I ran `npm run test` and manually tried to install `@nestjs/cli` with `node npq/bin/npq-hero.js install @nestjs/cli@latest --global` to make sure that it solved the issue. I tried to see if I could add a test for this use case but I think you don't test individual marshalls.

## Checklist:
- N/A I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
