### PR TITLE
fix: use fetch json interface

### DIFF
--- a/__tests__/packageRepoUtils.test.js
+++ b/__tests__/packageRepoUtils.test.js
@@ -3,7 +3,7 @@ const fetch = require('node-fetch')
 
 jest.mock('node-fetch')
 fetch.mockImplementation(() => Promise.resolve({
-  data: require('./mocks/registryPackageOk.mock.json')
+  json: () => require('./mocks/registryPackageOk.mock.json')
 }))
 
 beforeEach(() => {
@@ -63,7 +63,7 @@ test('repo utils retrieves package README information', async () => {
 test('repo utils retrieves package latest version as null if not exists', async () => {
   const PackageRepoUtils = require('../lib/helpers/packageRepoUtils')
   fetch.mockReturnValue(Promise.resolve({
-    data: require('./mocks/registryPackageUnpublished.mock.json')
+    json: () => require('./mocks/registryPackageUnpublished.mock.json')
   }))
 
   const packageRepoUtils = new PackageRepoUtils()
@@ -75,12 +75,12 @@ test('repo utils retrieves package latest version as null if not exists', async 
 test('repo utils retrieves package download count', async () => {
   const PackageRepoUtils = require('../lib/helpers/packageRepoUtils')
   fetch.mockReturnValue(Promise.resolve({
-    data: {
+    json: () => ({
       downloads: 1950,
       start: '2017-11-26',
       end: '2017-12-25',
       package: 'express-version-route'
-    }
+    })
   }))
 
   const packageRepoUtils = new PackageRepoUtils()
@@ -92,7 +92,7 @@ test('repo utils retrieves package download count', async () => {
 test('repo utils retrieves package README information even when not available', async () => {
   const PackageRepoUtils = require('../lib/helpers/packageRepoUtils')
   fetch.mockReturnValue(Promise.resolve({
-    data: require('./mocks/registryPackageUnpublished.mock.json')
+    json: () => require('./mocks/registryPackageUnpublished.mock.json')
   }))
 
   const packageRepoUtils = new PackageRepoUtils()
@@ -104,7 +104,7 @@ test('repo utils retrieves package README information even when not available', 
 test('repo utils retrieves package LICENSE information', async () => {
   const PackageRepoUtils = require('../lib/helpers/packageRepoUtils')
   fetch.mockReturnValue(Promise.resolve({
-    data: require('./mocks/registryPackageOk.mock.json')
+    json: () => require('./mocks/registryPackageOk.mock.json')
   }))
 
   const packageRepoUtils = new PackageRepoUtils()
@@ -116,7 +116,7 @@ test('repo utils retrieves package LICENSE information', async () => {
 test('repo utils parses package version', async () => {
   const PackageRepoUtils = require('../lib/helpers/packageRepoUtils')
   fetch.mockReturnValue(Promise.resolve({
-    data: require('./mocks/registryPackageOk.mock.json')
+    json: () => require('./mocks/registryPackageOk.mock.json')
   }))
 
   const packageRepoUtils = new PackageRepoUtils()

--- a/lib/helpers/packageRepoUtils.js
+++ b/lib/helpers/packageRepoUtils.js
@@ -23,9 +23,10 @@ class PackageRepoUtils {
       return Promise.resolve(this.pkgInfoCache[pkg])
     } else {
       return fetch(`${this.registryUrl}/${this.formatPackageForUrl(pkg)}`)
-        .then(response => {
-          this.pkgInfoCache[pkg] = response.data
-          return response.data
+        .then(response => response.json())
+        .then(data => {
+          this.pkgInfoCache[pkg] = data
+          return data
         })
     }
   }
@@ -42,23 +43,18 @@ class PackageRepoUtils {
 
   getDownloadInfo (pkg) {
     return fetch(`${this.registryApiUrl}/downloads/point/last-month/${pkg}`)
-      .then(response => {
-        return response.data['downloads']
-      })
+      .then(response => response.json())
+      .then(({ downloads }) => downloads)
   }
 
   getReadmeInfo (pkg) {
     return this.getPackageInfo(pkg)
-      .then(data => {
-        return data['readme']
-      })
+      .then(({ readme }) => readme)
   }
 
   getLicenseInfo (pkg) {
     return this.getPackageInfo(pkg)
-      .then(data => {
-        return data['license']
-      })
+      .then(({ license }) => license)
   }
 
   parsePackageVersion (version) {

--- a/lib/marshalls/snyk.marshall.js
+++ b/lib/marshalls/snyk.marshall.js
@@ -63,18 +63,17 @@ class Marshall extends BaseMarshall {
     const url = encodeURI(`${SNYK_TEST_URL}/${packageName}/${packageVersion}?type=json`)
 
     return fetch(url)
-      .then(response => {
+      .then(response => response.json())
+      .then(data => {
         // format returned results the way that the
         // official test API endpoint returns them in
-        if (response && response.data && response.data.hasOwnProperty('totalVulns')) {
+        if (data && data.hasOwnProperty('totalVulns')) {
           return {
-            issuesCount: response.data.totalVulns
+            issuesCount: data.totalVulns
           }
         }
       })
-      .catch(() => {
-        return false
-      })
+      .catch(() => false)
   }
 
   getSnykVulnInfo ({ packageName, packageVersion } = {}) {
@@ -89,18 +88,17 @@ class Marshall extends BaseMarshall {
         Authorization: `token ${this.snykApiToken}`
       }
     })
-      .then(response => {
-        if (response && response.data && response.data.issues && response.data.issues.vulnerabilities) {
+      .then(response => response.json())
+      .then(data => {
+        if (data && data.issues && data.issues.vulnerabilities) {
           return {
-            issuesCount: response.data.issues.vulnerabilities.length
+            issuesCount: data.issues.vulnerabilities.length
           }
         }
 
         return false
       })
-      .catch(() => {
-        return false
-      })
+      .catch(() => false)
   }
 
   getSnykToken () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use [JSON response interface of fetch (and node-fetch)](https://www.npmjs.com/package/node-fetch#json)
![](https://user-images.githubusercontent.com/516342/100934617-af724480-34f7-11eb-9abb-08faa2a8d67e.png)
TBH, I don't understand how this is working for you guys...

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#176 176

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This application did not work on my machine at all

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
Ran on my machine with success for multiple packages

## Screenshots (if appropriate):

| Before | After
| - | -
| ![](https://user-images.githubusercontent.com/516342/100932340-64a2fd80-34f4-11eb-8be6-feffea36f6cb.png) | ![](https://user-images.githubusercontent.com/516342/100932378-74badd00-34f4-11eb-9192-2ca519b98cd5.png)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
