### PR TITLE
Fix issue with git urls being unsupported for repo 

### DIFF
--- a/__tests__/marshalls.repo.test.js
+++ b/__tests__/marshalls.repo.test.js
@@ -28,90 +28,111 @@ const fullPkgData = {
   }
 }
 
-test('has the right title', async () => {
-  expect(testMarshall.title()).toEqual('Identifying package repository...')
-})
+describe('Repo test suites', () => {
 
-test('throws the right error when there is no pkg data available', async () => {
-  await expect(testMarshall.validate({ packageName: {} })).rejects.toThrow(
-    'the package has no associated repository or homepage.'
-  )
-})
+  beforeEach( () => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+  })
 
-test('throws the right error when there is no repo in the pkg data', async () => {
-  const pkgData = {
-    packageName: {
-      'dist-tags': {
-        latest: '1.0.0'
-      },
-      versions: {
-        '1.0.0': {}
-      }
-    }
-  }
+  test('has the right title', async () => {
+    expect(testMarshall.title()).toEqual('Identifying package repository...')
+  })
 
-  await expect(testMarshall.validate(pkgData)).rejects.toThrow(
-    'the package has no associated repository or homepage.'
-  )
-})
+  test('throws the right error when there is no pkg data available', async () => {
+    await expect(testMarshall.validate({ packageName: {} })).rejects.toThrow(
+      'the package has no associated repository or homepage.'
+    )
+  })
 
-test('throws the right error when there is no repo URL in the pkg data', async () => {
-  const pkgData = {
-    packageName: {
-      'dist-tags': {
-        latest: '1.0.0'
-      },
-      versions: {
-        '1.0.0': {
-          repository: {}
+  test('throws the right error when there is no repo in the pkg data', async () => {
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {}
         }
       }
     }
-  }
 
-  await expect(testMarshall.validate(pkgData)).rejects.toThrow(
-    'the package has no associated repository or homepage.'
-  )
-})
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
+      'the package has no associated repository or homepage.'
+    )
+  })
 
-test('throws the right error when the repository url does not exist', async () => {
-  fetch.mockImplementationOnce(() =>
-    Promise.reject(new Error('error'))
-  )
-
-  await expect(testMarshall.validate(fullPkgData)).rejects.toThrow(
-    'the repository associated with the package (url) does not exist or is unreachable at the moment.'
-  )
-})
-
-test('throws the right error when the homepage url does not exist', async () => {
-  fetch.mockImplementationOnce(() =>
-    Promise.reject(new Error('error'))
-  )
-
-  const pkgData = {
-    packageName: {
-      'dist-tags': {
-        latest: '1.0.0'
-      },
-      versions: {
-        '1.0.0': {
-          repository: {},
-          homepage: 'homepage-url'
+  test('throws the right error when there is no repo URL in the pkg data', async () => {
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {
+            repository: {}
+          }
         }
       }
     }
-  }
 
-  await expect(testMarshall.validate(pkgData)).rejects.toThrow(
-    'the homepage associated with the package (homepage-url) does not exist or is unreachable at the moment.'
-  )
-})
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
+      'the package has no associated repository or homepage.'
+    )
+  })
 
-test('does not throw any errors if the url exists', async () => {
-  fetch.mockImplementationOnce(() =>
-    Promise.resolve('success')
-  )
+  test('throws the right error when the repository url does not exist', async () => {
+    fetch.mockImplementationOnce(() =>
+      Promise.reject(new Error('error'))
+    )
 
-  await expect(testMarshall.validate(fullPkgData)).resolves.toEqual(expect.anything())
+    await expect(testMarshall.validate(fullPkgData)).rejects.toThrow(
+      'no valid repository is associated with the package'
+    )
+  })
+
+  test('throws the right error when the repository url is unreachable', async () => {
+    fetch.mockImplementationOnce(() =>
+      Promise.reject(new Error('error'))
+    )
+
+    fullPkgData.packageName.versions['1.0.0'].repository.url = "https://dsfsdfsdfs.abcdeugwecwekjasda.com/" 
+    await expect(testMarshall.validate(fullPkgData)).rejects.toThrow(
+      'the repository associated with the package (https://dsfsdfsdfs.abcdeugwecwekjasda.com/) does not exist or is unreachable at the moment.'
+    )
+  })
+
+  test('throws the right error when the homepage url does not exist', async () => {
+    fetch.mockImplementationOnce(() =>
+      Promise.reject(new Error('error'))
+    )
+
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {
+            repository: {},
+            homepage: 'homepage-url'
+          }
+        }
+      }
+    }
+
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
+      'the homepage associated with the package (homepage-url) does not exist or is unreachable at the moment.'
+    )
+  })
+
+  test('does not throw any errors if the url exists', async () => {
+    fetch.mockImplementationOnce(() =>
+      Promise.resolve('success')
+    )
+
+    fullPkgData.packageName.versions['1.0.0'].repository.url = "https://google.com" 
+    await expect(testMarshall.validate(fullPkgData)).resolves.toEqual(expect.anything())
+  })
+
 })

--- a/__tests__/marshalls.repo.test.js
+++ b/__tests__/marshalls.repo.test.js
@@ -29,8 +29,7 @@ const fullPkgData = {
 }
 
 describe('Repo test suites', () => {
-
-  beforeEach( () => {
+  beforeEach(() => {
     jest.clearAllMocks()
     jest.resetAllMocks()
   })
@@ -96,7 +95,7 @@ describe('Repo test suites', () => {
       Promise.reject(new Error('error'))
     )
 
-    fullPkgData.packageName.versions['1.0.0'].repository.url = "https://dsfsdfsdfs.abcdeugwecwekjasda.com/" 
+    fullPkgData.packageName.versions['1.0.0'].repository.url = 'https://dsfsdfsdfs.abcdeugwecwekjasda.com/'
     await expect(testMarshall.validate(fullPkgData)).rejects.toThrow(
       'the repository associated with the package (https://dsfsdfsdfs.abcdeugwecwekjasda.com/) does not exist or is unreachable at the moment.'
     )
@@ -131,8 +130,7 @@ describe('Repo test suites', () => {
       Promise.resolve('success')
     )
 
-    fullPkgData.packageName.versions['1.0.0'].repository.url = "https://google.com" 
+    fullPkgData.packageName.versions['1.0.0'].repository.url = 'https://google.com'
     await expect(testMarshall.validate(fullPkgData)).resolves.toEqual(expect.anything())
   })
-
 })

--- a/lib/marshalls/repo.marshall.js
+++ b/lib/marshalls/repo.marshall.js
@@ -25,7 +25,7 @@ class Marshall extends BaseMarshall {
           urlStructure = new URL(lastVersionData.repository.url)
           urlOfGitRepository = new URL(`https://${urlStructure.host}${urlStructure.pathname}`)
         } catch (error) {
-          throw new Error(`the repository associated with the package (${urlOfGitRepository.href}) does not exist or is unreachable at the moment.`)
+          throw new Error(`no valid repository is associated with the package`)
         }
         return fetch(urlOfGitRepository.href)
           .catch(() => {

--- a/lib/marshalls/repo.marshall.js
+++ b/lib/marshalls/repo.marshall.js
@@ -2,6 +2,7 @@
 
 const BaseMarshall = require('./baseMarshall')
 const fetch = require('node-fetch')
+const URL = require('url').URL
 const MARSHALL_NAME = 'repo'
 
 class Marshall extends BaseMarshall {
@@ -19,9 +20,11 @@ class Marshall extends BaseMarshall {
       const lastVersionData = (data.versions && data['dist-tags'] && data['dist-tags'].latest &&
         data.versions[data['dist-tags'].latest]) || data
       if (lastVersionData && lastVersionData.repository && lastVersionData.repository.url) {
-        return fetch(lastVersionData.repository.url)
+        const urlStructure = new URL(lastVersionData.repository.url)
+        const urlOfGitRepository = new URL(`https://${urlStructure.host}${urlStructure.pathname}`)
+        return fetch(urlOfGitRepository.href)
           .catch(() => {
-            throw new Error(`the repository associated with the package (${lastVersionData.repository.url}) does not exist or is unreachable at the moment.`)
+            throw new Error(`the repository associated with the package (${urlOfGitRepository.href}) does not exist or is unreachable at the moment.`)
           })
       } else if (lastVersionData && lastVersionData.homepage) {
         return fetch(lastVersionData.homepage)

--- a/lib/marshalls/repo.marshall.js
+++ b/lib/marshalls/repo.marshall.js
@@ -20,8 +20,13 @@ class Marshall extends BaseMarshall {
       const lastVersionData = (data.versions && data['dist-tags'] && data['dist-tags'].latest &&
         data.versions[data['dist-tags'].latest]) || data
       if (lastVersionData && lastVersionData.repository && lastVersionData.repository.url) {
-        const urlStructure = new URL(lastVersionData.repository.url)
-        const urlOfGitRepository = new URL(`https://${urlStructure.host}${urlStructure.pathname}`)
+        let urlStructure, urlOfGitRepository
+        try {
+          urlStructure = new URL(lastVersionData.repository.url)
+          urlOfGitRepository = new URL(`https://${urlStructure.host}${urlStructure.pathname}`)
+        } catch (error) {
+          throw new Error(`the repository associated with the package (${urlOfGitRepository.href}) does not exist or is unreachable at the moment.`)
+        }
         return fetch(urlOfGitRepository.href)
           .catch(() => {
             throw new Error(`the repository associated with the package (${urlOfGitRepository.href}) does not exist or is unreachable at the moment.`)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The URL of git repos takes the form of `git+https://` which is an invalid URL as is to access on the web, which caused repo URL checks to fail


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## How Has This Been Tested?

Updated relevant tests and fixed mocks usage within tests.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
