### PR TITLE
Disabled `postinstall` Prompt In NPM v7

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -11,7 +11,7 @@ const runPostInstall = async () => {
     return
   }
 
-  if (semver.gte(helpers.getNpmVersion(), '7.x.x')) {
+  if (semver.gte(helpers.getNpmVersion(), '7.0.0')) {
     // `npm install` in npm v7 cannot get stdin input, so we can't run this script there
     return
   }

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,12 +1,18 @@
 const fs = require('fs')
 const chalk = require('chalk')
 const inquirer = require('inquirer')
+const semver = require('semver')
 
 const helpers = require('./scriptHelpers')
 
 const runPostInstall = async () => {
   if (helpers.isRunningInYarn()) {
     // `yarn add` cannot get stdin input, so we can't run this script there
+    return
+  }
+
+  if (semver.gte(helpers.getNpmVersion(), '7.x.x')) {
+    // `npm install` in npm v7 cannot get stdin input, so we can't run this script there
     return
   }
 

--- a/scripts/scriptHelpers.js
+++ b/scripts/scriptHelpers.js
@@ -47,6 +47,11 @@ module.exports.isRunningInYarn = () => {
   return binaryName.toLowerCase().includes('yarn')
 }
 
+module.exports.getNpmVersion = () => {
+  const npmData = process.env['npm_config_user_agent'] || ''
+  return npmData.split(' ')[0].split('/')[1]
+}
+
 const getProfile = async (profilePath) => {
   try {
     // eslint-disable-next-line security/detect-non-literal-fs-filename

--- a/scripts/scriptHelpers.js
+++ b/scripts/scriptHelpers.js
@@ -1,6 +1,7 @@
 const fs = require('fs')
 const os = require('os')
 const path = require('path')
+const semver = require('semver')
 
 const BASH_ZSH_ALIASES = '\nalias npm="npq-hero"\nalias yarn="NPQ_PKG_MGR=yarn npq-hero"\n'
 const SHELLS = {
@@ -48,8 +49,9 @@ module.exports.isRunningInYarn = () => {
 }
 
 module.exports.getNpmVersion = () => {
-  const npmData = process.env['npm_config_user_agent'] || ''
-  return npmData.split(' ')[0].split('/')[1]
+  const npmData = process.env['npm_config_user_agent'] || '0.0.0'
+  const version = /npm\/(.*) node/.exec(npmData)[1]
+  return semver.valid(version) ? version : '0.0.0'
 }
 
 const getProfile = async (profilePath) => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In npm v7 the `postinstall` script longer accepts user input and does not show any messages to the user.
this make npq fails at installation in npm v7. to solve this I disabled the prompt in npm v7
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
Fixes #185 

## Motivation and Context
had a problem with installing npq in npm v7 and wanted to solve it.

## How Has This Been Tested?
Added automatic tests to the project. 
run the project on windows and ubuntu machines with both npm v6, npm v7, and yarn

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
