### PR TITLE
feat: add support for expired domains marshall

### DIFF
--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -1,0 +1,76 @@
+const ExpiredDomainsMarshall = require('../lib/marshalls/expiredDomains.marshall')
+
+jest.mock('node-fetch')
+
+const testMarshall = new ExpiredDomainsMarshall({
+  packageRepoUtils: {
+    getPackageInfo: (pkgInfo) => {
+      return new Promise((resolve) => {
+        resolve(pkgInfo)
+      })
+    }
+  }
+})
+
+describe('Expired domains test suites', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    jest.resetAllMocks()
+  })
+
+  test('has the right title', async () => {
+    expect(testMarshall.title()).toEqual('Detecting expired domains for authors account...')
+  })
+
+  test('throws the right error when an email domain cant be verified', async () => {
+    const nonExistentEmailAddress =
+      'liran.tal+test1234@somenonexistentdomainongoogle109dubv98g39ujasdasda.com'
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {
+            maintainers: [
+              { name: 'lirantal', email: 'liran.tal@gmail.com' },
+              {
+                name: 'lirantal_test_user',
+                email: nonExistentEmailAddress
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
+      /Unable to resolve domain for maintainer e-mail, could be an expired account/
+    )
+  })
+
+  test('does not throw any errors if the domain resolves well', async () => {
+    jest.setTimeout(15000)
+
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {
+            maintainers: [
+              { name: 'lirantal', email: 'liran.tal@gmail.com' },
+              {
+                name: 'lirantal_test_user',
+                email: 'liran.tal@gmail.com'
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    await expect(testMarshall.validate(pkgData)).resolves.toEqual(expect.anything())
+  })
+})

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -1,0 +1,45 @@
+'use strict'
+
+const BaseMarshall = require('./baseMarshall')
+const dns = require('dns').promises
+
+const MARSHALL_NAME = 'maintainers_expired_emails'
+
+class Marshall extends BaseMarshall {
+  constructor (options) {
+    super(options)
+    this.name = MARSHALL_NAME
+  }
+
+  title () {
+    return 'Detecting expired domains for authors account...'
+  }
+
+  validate (pkg) {
+    return this.packageRepoUtils
+      .getPackageInfo(pkg.packageName)
+      .then((data) => {
+        const lastVersionData =
+          data.versions && data['dist-tags'] && data.versions[data['dist-tags']['latest']]
+
+        let maintainersAccounts = lastVersionData && lastVersionData.maintainers
+
+        let testEmails = []
+        for (const maintainerInfo of maintainersAccounts) {
+          const maintainerEmail = maintainerInfo.email
+          const emailDomain = maintainerEmail.split('@')[1]
+          testEmails.push(dns.resolve(emailDomain))
+        }
+
+        return Promise.all(testEmails)
+      })
+      .catch((error) => {
+        throw new Error(
+          'Unable to resolve domain for maintainer e-mail, could be an expired account: ' +
+            error.hostname
+        )
+      })
+  }
+}
+
+module.exports = Marshall

--- a/package.json
+++ b/package.json
@@ -152,14 +152,14 @@
       "node/no-unsupported-features/node-builtins": [
         "error",
         {
-          "version": ">=10.1.0",
+          "version": ">=10.6.0",
           "ignores": []
         }
       ],
       "node/no-unsupported-features/es-syntax": [
         "error",
         {
-          "version": ">=10.1.0",
+          "version": ">=10.6.0",
           "ignores": []
         }
       ]


### PR DESCRIPTION
Fixes #208 

Introduces new marshall for expired domains, as sourced from the signal for weak npm packages in the research titled `What are Weak Links in the npm Supply Chain?` - we should be able to find and match packages which their maintainers have expired domains and warn on install.

