### PR TITLE
test: remove unnecessary module mocking

### DIFF
--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -1,7 +1,5 @@
 const ExpiredDomainsMarshall = require('../lib/marshalls/expiredDomains.marshall')
 
-jest.mock('node-fetch')
-
 const testMarshall = new ExpiredDomainsMarshall({
   packageRepoUtils: {
     getPackageInfo: (pkgInfo) => {


### PR DESCRIPTION
No need to mock HTTP calls, removing unnecessary mocking of modules using `jest.mock`