### PR TITLE
chore: use semantic-release one-off

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile --ignore-engines --ignore-scripts
       - name: release
-        run: yarn run semantic-release
+        run: npx semantic-release@21.0.2
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NPM_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Change

Use semantic-release pinned version and use it as a one-off from the registry 