### PR TITLE
Fix/undefined on unknown host

### DIFF
--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -47,6 +47,32 @@ describe('Expired domains test suites', () => {
     )
   })
 
+  test('if email hostname is empty then show an unknown message', async () => {
+    const nonExistentEmailAddress = ''
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {
+            maintainers: [
+              { name: 'lirantal', email: 'liran.tal@gmail.com' },
+              {
+                name: 'lirantal_test_user',
+                email: nonExistentEmailAddress
+              }
+            ]
+          }
+        }
+      }
+    }
+
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
+      /Unable to resolve domain for maintainer e-mail, could be an expired account <unknown>/
+    )
+  })
+
   test('does not throw any errors if the domain resolves well', async () => {
     jest.setTimeout(15000)
 

--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -69,7 +69,7 @@ describe('Expired domains test suites', () => {
     }
 
     await expect(testMarshall.validate(pkgData)).rejects.toThrow(
-      /Unable to resolve domain for maintainer e-mail, could be an expired account <unknown>/
+      /Unable to resolve domain for maintainer e-mail, could be an expired account: <unknown>/
     )
   })
 

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -34,9 +34,10 @@ class Marshall extends BaseMarshall {
         return Promise.all(testEmails)
       })
       .catch((error) => {
+        let emailHostname = error.hostname ? error.hostname : '<unknown>'
         throw new Error(
           'Unable to resolve domain for maintainer e-mail, could be an expired account: ' +
-            error.hostname
+            emailHostname
         )
       })
   }


### PR DESCRIPTION
## Fix

Fix for the `undefined` that shows up hostnames that are empty and can't be resolved:

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/316371/236683397-2f1016a3-6681-4114-9943-431e68d74b1e.png">
