### PR TITLE
fix: dont report on the package if it is popular

### DIFF
--- a/lib/marshalls/typosquatting.marshall.js
+++ b/lib/marshalls/typosquatting.marshall.js
@@ -23,8 +23,16 @@ class Marshall extends BaseMarshall {
   validate(pkg) {
     let levenshteinDistance = null
     let similarPackages = []
+    let packageFoundInTopPackages = false
     return new Promise((resolve, reject) => {
       for (const popularPackageNameInRepository of topPackagesRawJSON) {
+        // If the package to be installed is itself found within the Top Packages dataset
+        // then we don't report on it
+        if (pkg.packageName === popularPackageNameInRepository) {
+          packageFoundInTopPackages = true
+          return resolve([])
+        }
+
         levenshteinDistance = levenshtein.get(pkg.packageName, popularPackageNameInRepository)
 
         if (levenshteinDistance > 0 && levenshteinDistance < 3) {


### PR DESCRIPTION
Don't report on the package if it is found in the top popular packages dataset