### PR TITLE
fix: support for --save flag and others that are supported by npm cli

### DIFF
--- a/lib/cliCommons.js
+++ b/lib/cliCommons.js
@@ -33,6 +33,14 @@ class cliCommons {
 
   static getOptions() {
     return {
+      S: {
+        alias: ['save', 'save-prod', 'save-optional', 'save-bundle'],
+        type: 'boolean'
+      },
+      g: {
+        alias: 'global',
+        type: 'boolean'
+      },
       P: {
         alias: ['save-prod', 'peer'],
         type: 'boolean'


### PR DESCRIPTION
## Description
Fix #300 
Add support for `--save` flag and others that are supported by npm cli

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
