### PR TITLE
fix: remove duplicate entries from typosquatting marshall

### DIFF
--- a/__tests__/marshalls.typosquatting.test.js
+++ b/__tests__/marshalls.typosquatting.test.js
@@ -1,0 +1,67 @@
+const TyposquattingMarshall = require('../lib/marshalls/typosquatting.marshall')
+
+describe('Typosquatting Marshall', () => {
+  test('should remove duplicate entries from similar packages', async () => {
+    const typosquattingMarshall = new TyposquattingMarshall({
+      packageRepoUtils: null
+    })
+
+    // Mock the top packages data to include duplicates
+    const originalTopPackages = require('../data/top-packages.json')
+    
+    // Create a test package that would match multiple similar packages
+    const pkg = {
+      packageName: 'ghtml' // This should match 'html' which appears multiple times in the data
+    }
+
+    try {
+      await typosquattingMarshall.validate(pkg)
+      // If no error is thrown, the test should fail
+      expect(true).toBe(false)
+    } catch (error) {
+      // Check that the error message doesn't contain duplicate entries
+      const errorMessage = error.message
+      expect(errorMessage).toContain('Package name could be a typosquatting attempt for popular package(s):')
+      
+      // Extract the package names from the error message
+      const packagesList = errorMessage.split('popular package(s): ')[1]
+      const packages = packagesList.split(', ')
+      
+      // Check that there are no duplicates
+      const uniquePackages = [...new Set(packages)]
+      expect(packages.length).toBe(uniquePackages.length)
+      
+      // Verify that 'html' appears only once even though it exists multiple times in the data
+      const htmlCount = packages.filter(pkg => pkg === 'html').length
+      expect(htmlCount).toBe(1)
+    }
+  })
+
+  test('should not report typosquatting for packages in top packages list', async () => {
+    const typosquattingMarshall = new TyposquattingMarshall({
+      packageRepoUtils: null
+    })
+
+    // Test with a package that exists in the top packages list
+    const pkg = {
+      packageName: 'express' // This should be in the top packages list
+    }
+
+    const result = await typosquattingMarshall.validate(pkg)
+    expect(result).toEqual([])
+  })
+
+  test('should not report typosquatting for packages with no similar matches', async () => {
+    const typosquattingMarshall = new TyposquattingMarshall({
+      packageRepoUtils: null
+    })
+
+    // Test with a package that has no similar matches
+    const pkg = {
+      packageName: 'verylonganduniquenamethatdoesnotmatchanything'
+    }
+
+    const result = await typosquattingMarshall.validate(pkg)
+    expect(result).toEqual([])
+  })
+})

--- a/lib/marshalls/typosquatting.marshall.js
+++ b/lib/marshalls/typosquatting.marshall.js
@@ -41,9 +41,11 @@ class Marshall extends BaseMarshall {
       }
 
       if (similarPackages.length > 0) {
+        // Remove duplicates from similarPackages array
+        const uniqueSimilarPackages = [...new Set(similarPackages)]
         return reject(
           new Error(
-            `Package name could be a typosquatting attempt for popular package(s): ${similarPackages.join(
+            `Package name could be a typosquatting attempt for popular package(s): ${uniqueSimilarPackages.join(
               ', '
             )}`
           )


### PR DESCRIPTION
- Fixed issue where typosquatting marshall would show duplicate package names
- Added deduplication using Set to ensure unique package names in error messages
- Added comprehensive test suite to verify the fix works correctly
- Resolves issue #309 where 'html' was appearing multiple times in typosquatting warnings

<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix #309 

Implemented by Qodo Gen CLI ✨

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
