### PR TITLE
fix: handle Ctrl+C gracefully during interactive prompts

### DIFF
--- a/__tests__/cliPrompt.test.js
+++ b/__tests__/cliPrompt.test.js
@@ -408,4 +408,38 @@ describe('cliPrompt', () => {
       expect(result).toEqual({ undefined: true })
     }, 10000) // 10 second timeout
   })
+
+  describe('error handling', () => {
+    test('should handle ABORT_ERR gracefully when user presses Ctrl+C', async () => {
+      const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+      // Simulate the ABORT_ERR that readline throws on Ctrl+C
+      const abortError = new Error('The operation was aborted')
+      abortError.code = 'ABORT_ERR'
+      mockRl.question.mockRejectedValue(abortError)
+
+      try {
+        await prompt({ name: 'test', message: 'Test prompt?' })
+        expect(true).toBe(false) // Should not reach this line
+      } catch (error) {
+        expect(error.message).toBe('Operation aborted by user')
+        expect(error.code).toBe('USER_ABORT')
+        expect(error.exitCode).toBe(1)
+      }
+
+      expect(mockConsoleLog).toHaveBeenCalledWith('\nOperation aborted.')
+
+      mockConsoleLog.mockRestore()
+    })
+
+    test('should re-throw non-ABORT_ERR errors', async () => {
+      const otherError = new Error('Some other error')
+      otherError.code = 'OTHER_ERROR'
+      mockRl.question.mockRejectedValue(otherError)
+
+      await expect(prompt({ name: 'test', message: 'Test prompt?' })).rejects.toThrow(
+        'Some other error'
+      )
+    })
+  })
 })

--- a/bin/npq-hero.js
+++ b/bin/npq-hero.js
@@ -100,8 +100,18 @@ marshall
     }
   })
   .catch((error) => {
+    // Ensure errorCode is always a number
+    let errorCode = -1
+    if (typeof error.code === 'number') {
+      errorCode = error.code
+    } else if (error.code === 'ABORT_ERR') {
+      errorCode = 1
+    } else if (error.code === 'USER_ABORT') {
+      errorCode = error.exitCode || 1
+    }
+
     CliParser.exit({
-      errorCode: error.code || -1,
+      errorCode,
       message: error.message || 'An error occurred',
       spinner
     })

--- a/bin/npq.js
+++ b/bin/npq.js
@@ -126,8 +126,18 @@ Promise.resolve()
     }
   })
   .catch((error) => {
+    // Ensure errorCode is always a number
+    let errorCode = -1
+    if (typeof error.code === 'number') {
+      errorCode = error.code
+    } else if (error.code === 'ABORT_ERR') {
+      errorCode = 1
+    } else if (error.code === 'USER_ABORT') {
+      errorCode = error.exitCode || 1
+    }
+
     CliParser.exit({
-      errorCode: error.code || -1,
+      errorCode,
       message: error.message || 'An error occurred',
       spinner
     })

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,7 +14,9 @@ class CliParser {
       console.error(message)
     }
 
-    process.exit(errorCode || -1)
+    // Ensure errorCode is always a number
+    const exitCode = typeof errorCode === 'number' ? errorCode : -1
+    process.exit(exitCode)
   }
 
   static _extractPackagesFromPositionals(positionals, earlyExitNoInstall = false) {

--- a/lib/helpers/cliPrompt.js
+++ b/lib/helpers/cliPrompt.js
@@ -54,6 +54,17 @@ async function prompt(options = {}) {
     }
 
     return { [name]: result }
+  } catch (error) {
+    // Handle Ctrl+C gracefully - user cancelled the operation
+    if (error.code === 'ABORT_ERR') {
+      console.log('\nOperation aborted.')
+      // Throw a specific error that can be caught and handled by the caller
+      const abortError = new Error('Operation aborted by user')
+      abortError.code = 'USER_ABORT'
+      abortError.exitCode = 1
+      throw abortError
+    }
+    throw error
   } finally {
     rl.close()
   }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Fixes #364

- Handle ABORT_ERR gracefully in cliPrompt.js when user presses Ctrl+C
- Ensure exit codes are always numeric in CLI error handlers
- Add proper error handling for user-initiated prompt abortion
- Add comprehensive tests for Ctrl+C behavior
- Prevent TypeError by validating error code types before passing to process.exit()

The issue was caused by readline throwing an error with code 'ABORT_ERR' (string) when Ctrl+C is pressed, but our error handlers were passing this string directly to process.exit() which expects a numeric exit code.

Changes:
- lib/helpers/cliPrompt.js: Transform ABORT_ERR into USER_ABORT error with numeric exitCode
- bin/npq.js & bin/npq-hero.js: Add type checking for error codes
- lib/cli.js: Ensure exit function always receives numeric exit codes
- __tests__/cliPrompt.test.js: Add tests for Ctrl+C handling

<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
