### PR TITLE
feat: improve CLI countdown UX with single-line display

### DIFF
--- a/__tests__/cliPrompt.test.js
+++ b/__tests__/cliPrompt.test.js
@@ -342,8 +342,8 @@ describe('cliPrompt', () => {
 
       await promise
 
-      // Should write initial message with starting number
-      expect(mockWrite).toHaveBeenCalledWith('Testing in 3')
+      // Should write initial message with starting number and instruction
+      expect(mockWrite).toHaveBeenCalledWith("Testing in 3 (press 'y' to proceed)")
     })
 
     test('should handle single digit countdown correctly', async () => {
@@ -358,8 +358,8 @@ describe('cliPrompt', () => {
 
       await promise
 
-      // Should write initial message
-      expect(mockWrite).toHaveBeenCalledWith('Starting in 2')
+      // Should write initial message with instruction
+      expect(mockWrite).toHaveBeenCalledWith("Starting in 2 (press 'y' to proceed)")
     })
 
     test('should handle double digit to single digit countdown with padding', async () => {
@@ -374,8 +374,8 @@ describe('cliPrompt', () => {
 
       await promise
 
-      // Should write initial message with double digit
-      expect(mockWrite).toHaveBeenCalledWith('Waiting 10')
+      // Should write initial message with double digit and instruction
+      expect(mockWrite).toHaveBeenCalledWith("Waiting 10 (press 'y' to proceed)")
     }, 15000) // 15 second timeout
 
     test('should call console.log at the end', async () => {
@@ -392,7 +392,8 @@ describe('cliPrompt', () => {
 
       await promise
 
-      expect(mockConsoleLog).toHaveBeenCalledWith()
+      // Should only call console.log at the end with empty line (no separate instruction line)
+      expect(mockConsoleLog).toHaveBeenCalledWith('')
       mockConsoleLog.mockRestore()
     })
 
@@ -450,6 +451,61 @@ describe('cliPrompt', () => {
         jest.runAllTimers()
 
         await expect(promise).rejects.toThrow('Operation aborted by user')
+      } finally {
+        // Restore timers and original methods
+        jest.useRealTimers()
+        process.stdin.isTTY = originalIsTTY
+        process.stdin.setRawMode = originalSetRawMode
+        process.stdin.resume = originalResume
+        process.stdin.pause = originalPause
+        process.stdin.on = originalOn
+        process.stdin.removeListener = originalRemoveListener
+      }
+    }, 10000)
+
+    test('should handle "y" key to proceed immediately during countdown', async () => {
+      // Use fake timers for this test
+      jest.useFakeTimers()
+
+      // Mock process.stdin for this test
+      const originalIsTTY = process.stdin.isTTY
+      const originalSetRawMode = process.stdin.setRawMode
+      const originalResume = process.stdin.resume
+      const originalPause = process.stdin.pause
+      const originalOn = process.stdin.on
+      const originalRemoveListener = process.stdin.removeListener
+
+      let dataListener = null
+
+      process.stdin.isTTY = true
+      process.stdin.setRawMode = jest.fn()
+      process.stdin.resume = jest.fn()
+      process.stdin.pause = jest.fn()
+      process.stdin.on = jest.fn((event, listener) => {
+        if (event === 'data') {
+          dataListener = listener
+        }
+      })
+      process.stdin.removeListener = jest.fn()
+
+      try {
+        const promise = autoContinue({ name: 'test', message: 'Testing... ', timeInSeconds: 10 })
+
+        // Advance timers a bit to let the function start
+        jest.advanceTimersByTime(100)
+
+        // Simulate "y" keypress (ASCII 121)
+        if (dataListener) {
+          const yKey = Buffer.from([121])
+          dataListener(yKey)
+        }
+
+        // Fast-forward remaining timers
+        jest.runAllTimers()
+
+        const result = await promise
+
+        expect(result).toEqual({ test: true })
       } finally {
         // Restore timers and original methods
         jest.useRealTimers()

--- a/__tests__/cliPrompt.test.js
+++ b/__tests__/cliPrompt.test.js
@@ -407,6 +407,60 @@ describe('cliPrompt', () => {
       // Should handle undefined name gracefully
       expect(result).toEqual({ undefined: true })
     }, 10000) // 10 second timeout
+
+    test('should handle Ctrl+C during autoContinue countdown', async () => {
+      // Use fake timers for this test
+      jest.useFakeTimers()
+
+      // Mock process.stdin for this test
+      const originalIsTTY = process.stdin.isTTY
+      const originalSetRawMode = process.stdin.setRawMode
+      const originalResume = process.stdin.resume
+      const originalPause = process.stdin.pause
+      const originalOn = process.stdin.on
+      const originalRemoveListener = process.stdin.removeListener
+
+      let dataListener = null
+
+      process.stdin.isTTY = true
+      process.stdin.setRawMode = jest.fn()
+      process.stdin.resume = jest.fn()
+      process.stdin.pause = jest.fn()
+      process.stdin.on = jest.fn((event, listener) => {
+        if (event === 'data') {
+          dataListener = listener
+        }
+      })
+      process.stdin.removeListener = jest.fn()
+
+      try {
+        const promise = autoContinue({ name: 'test', message: 'Testing... ', timeInSeconds: 3 })
+
+        // Advance timers a bit to let the function start
+        jest.advanceTimersByTime(100)
+
+        // Simulate Ctrl+C keypress
+        if (dataListener) {
+          // Simulate Ctrl+C (ASCII 3)
+          const ctrlC = Buffer.from([3])
+          dataListener(ctrlC)
+        }
+
+        // Fast-forward remaining timers
+        jest.runAllTimers()
+
+        await expect(promise).rejects.toThrow('Operation aborted by user')
+      } finally {
+        // Restore timers and original methods
+        jest.useRealTimers()
+        process.stdin.isTTY = originalIsTTY
+        process.stdin.setRawMode = originalSetRawMode
+        process.stdin.resume = originalResume
+        process.stdin.pause = originalPause
+        process.stdin.on = originalOn
+        process.stdin.removeListener = originalRemoveListener
+      }
+    }, 10000)
   })
 
   describe('error handling', () => {

--- a/docs/feature/auto-continue.md
+++ b/docs/feature/auto-continue.md
@@ -1,0 +1,182 @@
+# Auto-Continue Feature
+
+The auto-continue feature provides a user-friendly way to automatically proceed with package installation after a configurable countdown when only warnings (not errors) are detected during security auditing.
+
+## Overview
+
+When npq detects security warnings but no errors during package auditing, it automatically starts a countdown timer that allows the installation to proceed without user intervention. This streamlines the workflow for packages that have minor security concerns but are still considered safe to install.
+
+## When Auto-Continue Activates
+
+The auto-continue feature activates when:
+
+1. **Security audit completes** with warnings but **no errors**
+2. **At least one warning** is found (if no warnings, installation proceeds immediately)
+3. User has **not explicitly chosen** to always prompt for confirmation
+
+## User Experience
+
+### Visual Display
+
+```
+Packages with issues found:
+
+ ┌─
+ │ >  express@latest
+ │
+ │ ⚠ Supply Chain Security · Unable to verify provenance: the package was published without any attestations 
+ └─
+
+Summary:
+
+ - Total packages: 1
+ - Total errors:   0
+ - Total warnings: 1
+
+(press 'y' to proceed with install)
+Auto-continue with install in... 15
+```
+
+The countdown displays the remaining seconds, updating in real-time by using backspace characters to overwrite the previous number. An instruction message is shown above the countdown to inform users they can press 'y' to proceed immediately.
+
+### Countdown Behavior
+
+- **Default Duration**: 15 seconds
+- **Real-time Updates**: Numbers count down from 15 to 1
+- **Smart Padding**: Handles transitions from double-digit to single-digit numbers cleanly
+- **Clean Display**: Keystrokes during countdown are ignored to prevent visual corruption
+
+## User Interaction Options
+
+### During Countdown
+
+| Action | Behavior | Exit Code |
+|--------|----------|-----------|
+| **Wait** | Installation proceeds automatically after countdown | `0` (success) |
+| **Press 'y' or 'Y'** | Skips countdown and proceeds immediately with installation | `0` (success) |
+| **Ctrl+C** | Aborts installation immediately | `1` (user abort) |
+| **Other Keys** | Ignored (no visual output) | - |
+
+### Graceful Abortion
+
+When users press `Ctrl+C` during the countdown:
+
+1. **Immediate Response**: Countdown stops instantly
+2. **Clean Exit**: No error stack trace displayed
+3. **Proper Cleanup**: Terminal state restored to normal
+4. **Error Handling**: Throws `USER_ABORT` error with exit code `1`
+
+## Technical Implementation
+
+### Core Function
+
+```javascript
+autoContinue({ name, message, timeInSeconds = 5 })
+```
+
+**Parameters:**
+- `name`: Property name for the returned result object
+- `message`: Text displayed before the countdown
+- `timeInSeconds`: Duration of countdown (default: 5, npq uses 15)
+
+**Returns:**
+- `Promise<Object>`: Resolves to `{ [name]: true }` on completion
+- **Throws**: `USER_ABORT` error if user presses Ctrl+C
+
+### TTY Detection and Behavior
+
+#### Interactive Terminals (TTY)
+- **Stdin Control**: Sets raw mode to capture individual keypresses
+- **Keypress Filtering**: Only responds to Ctrl+C (ASCII 3), ignores others
+- **Clean Restoration**: Restores normal stdin behavior after completion
+
+#### Non-Interactive Environments
+- **Fallback Mode**: Standard countdown without stdin manipulation
+- **Test Compatibility**: Works in CI/CD and testing environments
+- **Same Visual Output**: Maintains consistent user experience
+
+### Error Handling
+
+```javascript
+// Error thrown on Ctrl+C
+{
+  message: 'Operation aborted by user',
+  code: 'USER_ABORT',
+  exitCode: 1
+}
+```
+
+## Configuration
+
+Currently, the auto-continue feature uses hardcoded values:
+
+- **Countdown Duration**: 15 seconds (defined in `bin/npq.js` and `bin/npq-hero.js`)
+- **Trigger Condition**: Warnings > 0 and Errors = 0
+- **Message**: "Auto-continue with install in... "
+
+## Usage Context
+
+### In npq Workflow
+
+1. **Package Analysis**: Security marshalls check package safety
+2. **Result Evaluation**: 
+   - **Errors > 0**: Manual prompt ("Continue install?")
+   - **Warnings > 0, Errors = 0**: Auto-continue countdown
+   - **No Issues**: Immediate installation
+3. **User Decision**: During countdown, user can abort or let it proceed
+
+### Integration Points
+
+- **Main Binary**: `bin/npq.js` (line ~109)
+- **Hero Mode**: `bin/npq-hero.js` (line ~83)
+- **Implementation**: `lib/helpers/cliPrompt.js`
+
+### Recent Improvements
+
+### "Y" Key Skip Feature
+
+**Enhancement**: Users can now press 'y' or 'Y' during the countdown to immediately proceed with installation without waiting for the timer to complete.
+
+**Benefits**:
+- Faster workflow for users who want to proceed immediately
+- Clear instruction displayed above countdown
+- Maintains all existing functionality (Ctrl+C abort, automatic completion)
+
+### Keystroke Interference Fix
+
+**Problem**: Previously, typing during countdown would display characters and corrupt the countdown display (e.g., `11311187^C%`).
+
+**Solution**: 
+- Raw mode stdin capture prevents character echo
+- Keypress filtering ignores non-control characters
+- Clean countdown display maintained
+
+### Enhanced Ctrl+C Handling
+
+**Problem**: Ctrl+C during countdown caused TypeError crashes.
+
+**Solution**:
+- Proper signal handling with graceful error throwing
+- Consistent error codes and messaging
+- Clean terminal state restoration
+
+## Future Enhancements
+
+Potential improvements could include:
+
+- **Configurable Duration**: Allow users to set countdown time via CLI flags or config
+- **Sound Notifications**: Optional audio alerts during countdown
+- **Custom Messages**: Configurable countdown messages
+- **Additional Skip Keys**: Support for other keys like Enter or Space to proceed
+- **Visual Indicators**: Progress bars or other visual countdown representations
+
+## Testing
+
+The auto-continue feature includes comprehensive test coverage:
+
+- **Normal Operation**: Countdown completion and result return
+- **User Abortion**: Ctrl+C handling and error throwing
+- **Edge Cases**: Various countdown durations and parameter combinations
+- **Environment Support**: Both TTY and non-TTY environment testing
+
+See `__tests__/cliPrompt.test.js` for complete test scenarios.

--- a/lib/helpers/cliPrompt.js
+++ b/lib/helpers/cliPrompt.js
@@ -70,35 +70,112 @@ async function prompt(options = {}) {
 }
 
 async function autoContinue({ name, message, timeInSeconds = 5 } = {}) {
-  // Show initial message with countdown
-  process.stdout.write(`${message}${timeInSeconds}`)
+  let aborted = false
 
-  // Count down from timeInSeconds-1 to 1
-  for (let i = timeInSeconds - 1; i > 0; i--) {
+  // Setup stdin to capture keypresses during countdown
+  if (process.stdin.isTTY) {
+    process.stdin.setRawMode(true)
+    process.stdin.resume()
+
+    // Handle keypresses during countdown
+    const onKeypress = (chunk) => {
+      // Check for Ctrl+C (ASCII 3)
+      if (chunk && chunk.length === 1 && chunk[0] === 3) {
+        aborted = true
+      }
+      // Ignore all other keypresses during countdown
+    }
+
+    process.stdin.on('data', onKeypress)
+
+    // Cleanup function
+    const cleanup = () => {
+      process.stdin.removeListener('data', onKeypress)
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false)
+        process.stdin.pause()
+      }
+    }
+
+    try {
+      // Show initial message with countdown
+      process.stdout.write(`${message}${timeInSeconds}`)
+
+      // Count down from timeInSeconds-1 to 1
+      for (let i = timeInSeconds - 1; i > 0 && !aborted; i--) {
+        await setTimeout(1000)
+
+        if (aborted) break
+
+        // Calculate how many characters to backspace (previous number length)
+        const prevNumber = i + 1
+        const prevLength = prevNumber.toString().length
+        const currentLength = i.toString().length
+
+        // Backspace to beginning of number
+        const backspaces = '\b'.repeat(prevLength)
+
+        // Write new number and pad with spaces if needed to clear any remaining digits
+        const padding = ' '.repeat(Math.max(0, prevLength - currentLength))
+        const moveBack = '\b'.repeat(Math.max(0, prevLength - currentLength))
+
+        process.stdout.write(`${backspaces}${i}${padding}${moveBack}`)
+      }
+
+      if (!aborted) {
+        // Wait for the final second
+        await setTimeout(1000)
+
+        // Move to next line after countdown completes
+        console.log()
+      }
+
+      cleanup()
+
+      if (aborted) {
+        const abortError = new Error('Operation aborted by user')
+        abortError.code = 'USER_ABORT'
+        abortError.exitCode = 1
+        throw abortError
+      }
+
+      return { [name]: true }
+    } catch (error) {
+      cleanup()
+      throw error
+    }
+  } else {
+    // Fallback for non-TTY environments (tests, etc.)
+    // Show initial message with countdown
+    process.stdout.write(`${message}${timeInSeconds}`)
+
+    // Count down from timeInSeconds-1 to 1
+    for (let i = timeInSeconds - 1; i > 0; i--) {
+      await setTimeout(1000)
+
+      // Calculate how many characters to backspace (previous number length)
+      const prevNumber = i + 1
+      const prevLength = prevNumber.toString().length
+      const currentLength = i.toString().length
+
+      // Backspace to beginning of number
+      const backspaces = '\b'.repeat(prevLength)
+
+      // Write new number and pad with spaces if needed to clear any remaining digits
+      const padding = ' '.repeat(Math.max(0, prevLength - currentLength))
+      const moveBack = '\b'.repeat(Math.max(0, prevLength - currentLength))
+
+      process.stdout.write(`${backspaces}${i}${padding}${moveBack}`)
+    }
+
+    // Wait for the final second
     await setTimeout(1000)
 
-    // Calculate how many characters to backspace (previous number length)
-    const prevNumber = i + 1
-    const prevLength = prevNumber.toString().length
-    const currentLength = i.toString().length
+    // Move to next line after countdown completes
+    console.log()
 
-    // Backspace to beginning of number
-    const backspaces = '\b'.repeat(prevLength)
-
-    // Write new number and pad with spaces if needed to clear any remaining digits
-    const padding = ' '.repeat(Math.max(0, prevLength - currentLength))
-    const moveBack = '\b'.repeat(Math.max(0, prevLength - currentLength))
-
-    process.stdout.write(`${backspaces}${i}${padding}${moveBack}`)
+    return { [name]: true }
   }
-
-  // Wait for the final second
-  await setTimeout(1000)
-
-  // Move to next line after countdown completes
-  console.log()
-
-  return { [name]: true }
 }
 
 module.exports = {

--- a/lib/helpers/cliPrompt.js
+++ b/lib/helpers/cliPrompt.js
@@ -71,6 +71,7 @@ async function prompt(options = {}) {
 
 async function autoContinue({ name, message, timeInSeconds = 5 } = {}) {
   let aborted = false
+  let userProceeded = false
 
   // Setup stdin to capture keypresses during countdown
   if (process.stdin.isTTY) {
@@ -82,6 +83,10 @@ async function autoContinue({ name, message, timeInSeconds = 5 } = {}) {
       // Check for Ctrl+C (ASCII 3)
       if (chunk && chunk.length === 1 && chunk[0] === 3) {
         aborted = true
+      }
+      // Check for 'y' or 'Y' (ASCII 121 or 89)
+      else if (chunk && chunk.length === 1 && (chunk[0] === 121 || chunk[0] === 89)) {
+        userProceeded = true
       }
       // Ignore all other keypresses during countdown
     }
@@ -98,36 +103,37 @@ async function autoContinue({ name, message, timeInSeconds = 5 } = {}) {
     }
 
     try {
-      // Show initial message with countdown
-      process.stdout.write(`${message}${timeInSeconds}`)
+      // Show countdown message with instruction in parentheses
+      process.stdout.write(`${message}${timeInSeconds} (press 'y' to proceed)`)
+
+      let currentNumber = timeInSeconds
 
       // Count down from timeInSeconds-1 to 1
-      for (let i = timeInSeconds - 1; i > 0 && !aborted; i--) {
+      for (let i = timeInSeconds - 1; i > 0 && !aborted && !userProceeded; i--) {
         await setTimeout(1000)
 
-        if (aborted) break
+        if (aborted || userProceeded) break
 
-        // Calculate how many characters to backspace (previous number length)
-        const prevNumber = i + 1
-        const prevLength = prevNumber.toString().length
-        const currentLength = i.toString().length
+        // Update the countdown number using backspace
+        // We need to backspace over both the number AND the instruction text
+        const instructionText = " (press 'y' to proceed)"
+        const totalTextLength = currentNumber.toString().length + instructionText.length
 
-        // Backspace to beginning of number
-        const backspaces = '\b'.repeat(prevLength)
+        // Backspace over everything, write new number and instruction
+        const backspaces = '\b'.repeat(totalTextLength)
+        process.stdout.write(`${backspaces}${i}${instructionText}`)
 
-        // Write new number and pad with spaces if needed to clear any remaining digits
-        const padding = ' '.repeat(Math.max(0, prevLength - currentLength))
-        const moveBack = '\b'.repeat(Math.max(0, prevLength - currentLength))
-
-        process.stdout.write(`${backspaces}${i}${padding}${moveBack}`)
+        currentNumber = i
       }
 
-      if (!aborted) {
+      if (!aborted && !userProceeded) {
         // Wait for the final second
         await setTimeout(1000)
+      }
 
-        // Move to next line after countdown completes
-        console.log()
+      // Move to a clean new line for any follow-up output
+      if (!aborted) {
+        console.log('') // Just move to next line
       }
 
       cleanup()
@@ -146,26 +152,21 @@ async function autoContinue({ name, message, timeInSeconds = 5 } = {}) {
     }
   } else {
     // Fallback for non-TTY environments (tests, etc.)
-    // Show initial message with countdown
-    process.stdout.write(`${message}${timeInSeconds}`)
+    // Show countdown message with instruction
+    process.stdout.write(`${message}${timeInSeconds} (press 'y' to proceed)`)
 
     // Count down from timeInSeconds-1 to 1
     for (let i = timeInSeconds - 1; i > 0; i--) {
       await setTimeout(1000)
 
-      // Calculate how many characters to backspace (previous number length)
+      // Update similar to TTY version - backspace over number and instruction
+      const instructionText = " (press 'y' to proceed)"
       const prevNumber = i + 1
-      const prevLength = prevNumber.toString().length
-      const currentLength = i.toString().length
+      const totalTextLength = prevNumber.toString().length + instructionText.length
 
-      // Backspace to beginning of number
-      const backspaces = '\b'.repeat(prevLength)
-
-      // Write new number and pad with spaces if needed to clear any remaining digits
-      const padding = ' '.repeat(Math.max(0, prevLength - currentLength))
-      const moveBack = '\b'.repeat(Math.max(0, prevLength - currentLength))
-
-      process.stdout.write(`${backspaces}${i}${padding}${moveBack}`)
+      // Backspace over everything, write new number and instruction
+      const backspaces = '\b'.repeat(totalTextLength)
+      process.stdout.write(`${backspaces}${i}${instructionText}`)
     }
 
     // Wait for the final second


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

    feat: improve CLI countdown UX with single-line display
    
    - Implement single-line countdown format: 'Auto-continue with install in... X (press 'y' to proceed)'
    - Add 'y' key functionality to proceed immediately during countdown
    - Update test expectations for new display format
    - Improve UX by combining countdown and instruction into one line
    - Add comprehensive feature documentation
    
    Resolves #364 and improves overall CLI interaction experience

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
