### PR TITLE
feat(snyk): allow custom API URL and token via env vars

### DIFF
--- a/lib/marshalls/snyk.marshall.js
+++ b/lib/marshalls/snyk.marshall.js
@@ -7,10 +7,7 @@ const BaseMarshall = require('./baseMarshall')
 const { marshallCategories } = require('./constants')
 
 const MARSHALL_NAME = 'snyk'
-const SNYK_API_URL = 'https://snyk.io/api/v1/vuln/npm'
-
 const SNYK_PACKAGE_PAGE = 'https://snyk.io/vuln/npm:'
-const SNYK_API_TOKEN = process.env.SNYK_TOKEN
 const SNYK_CONFIG_FILE = '.config/configstore/snyk.json'
 
 class Marshall extends BaseMarshall {
@@ -20,6 +17,11 @@ class Marshall extends BaseMarshall {
     this.categoryId = marshallCategories.SupplyChainSecurity.id
 
     this.snykApiToken = this.getSnykToken()
+    this.snykApiUrl = this.getSnykApiUrl()
+  }
+
+  getSnykApiUrl() {
+    return process.env.SNYK_API_URL || process.env.SNYK_API || 'https://snyk.io/api/v1/vuln/npm'
   }
 
   title() {
@@ -119,7 +121,7 @@ class Marshall extends BaseMarshall {
       return this.getOsvVulnerabilityInfo({ packageName, packageVersion })
     }
 
-    const url = `${SNYK_API_URL}/${encodeURIComponent(packageName + '@' + packageVersion)}`
+    const url = `${this.snykApiUrl}/${encodeURIComponent(packageName + '@' + packageVersion)}`
 
     return fetch(url, {
       headers: {
@@ -150,8 +152,11 @@ class Marshall extends BaseMarshall {
   }
 
   getSnykToken() {
-    if (SNYK_API_TOKEN) {
-      return SNYK_API_TOKEN
+    // Check for SNYK_API_TOKEN first, then fall back to SNYK_TOKEN
+    const snykApiToken = process.env.SNYK_API_TOKEN || process.env.SNYK_TOKEN
+
+    if (snykApiToken) {
+      return snykApiToken
     }
 
     const snykConfigPath = path.join(os.homedir(), SNYK_CONFIG_FILE)


### PR DESCRIPTION
### **User description**
Implements support for configuring Snyk integration via environment variables.\n\nChanges\n- API URL precedence: SNYK_API_URL -> SNYK_API -> https://snyk.io/api/v1/vuln/npm (default)\n- Token precedence: SNYK_API_TOKEN -> SNYK_TOKEN -> Snyk config file -> null\n- Keep SNYK_PACKAGE_PAGE as-is (not derived from API URL)\n- Evaluate API URL at runtime via getSnykApiUrl() for reliable testability and flexibility\n\nTests\n- Added unit tests for URL and token precedence, including default and fallback behaviors\n- Confirmed backward compatibility with existing SNYK_TOKEN and config file\n\nNotes\n- Pre-existing fs lint warnings are unchanged and unrelated to this feature.\n- All tests pass: full suite green locally.

Closes #382

Fixes #382 

___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add environment variable support for Snyk API configuration
  - SNYK_API_URL takes precedence over SNYK_API, then defaults to official URL
  - SNYK_API_TOKEN takes precedence over SNYK_TOKEN for authentication

- Implement runtime API URL evaluation via getSnykApiUrl() method

- Expand test coverage with comprehensive precedence and fallback scenarios

- Maintain backward compatibility with existing SNYK_TOKEN and config file


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variables"] -->|SNYK_API_URL| B["getSnykApiUrl()"]
  A -->|SNYK_API| B
  B -->|default| C["Official Snyk API"]
  D["SNYK_API_TOKEN"] -->|priority| E["getSnykToken()"]
  F["SNYK_TOKEN"] -->|fallback| E
  G["Config File"] -->|fallback| E
  E -->|token| H["Snyk API Request"]
  C -->|url| H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>snyk.marshall.js</strong><dd><code>Implement runtime API URL and token configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/marshalls/snyk.marshall.js

<ul><li>Removed hardcoded SNYK_API_URL constant and moved to runtime <br>evaluation<br> <li> Added getSnykApiUrl() method implementing precedence: SNYK_API_URL → <br>SNYK_API → default<br> <li> Updated getSnykToken() to check SNYK_API_TOKEN before SNYK_TOKEN<br> <li> Modified getSnykVulnInfo() to use this.snykApiUrl instead of constant<br> <li> Store snykApiUrl in constructor for consistent runtime evaluation</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/npq/pull/383/files#diff-6b412544f75efc671a2c44b3e4db521176c3f08ef8590f0dd4ce795174b712a1">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>marshalls.snyk.test.js</strong><dd><code>Expand tests for environment variable precedence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

__tests__/marshalls.snyk.test.js

<ul><li>Refactored test setup to properly mock fs and os modules in beforeEach<br> <li> Added afterEach cleanup to clear require cache for module reloading<br> <li> Added test for SNYK_API_TOKEN environment variable support<br> <li> Added test verifying SNYK_API_TOKEN takes priority over SNYK_TOKEN<br> <li> Added test for fallback behavior when SNYK_API_TOKEN is not set<br> <li> Added test for config file fallback when both env vars are absent<br> <li> Added comprehensive test suite for custom Snyk API URL precedence<br> <li> Added integration tests verifying fetch calls use correct custom URLs</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/npq/pull/383/files#diff-59e6b68a9c34ec701be92a1fb988a28ea9cfd38cd8e6750cc747750dbff82234">+196/-1</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

