### PR TITLE
Check package devDependencies when running `npq`

### DIFF
--- a/__tests__/sourcePackages.test.js
+++ b/__tests__/sourcePackages.test.js
@@ -1,0 +1,135 @@
+'use strict'
+
+jest.mock('node:fs/promises')
+
+const fs = require('node:fs/promises')
+const { getProjectPackages } = require('../lib/helpers/sourcePackages')
+
+describe('sourcePackages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getProjectPackages', () => {
+    it('should return a flat array when both dependencies and devDependencies exist', async () => {
+      const mockPackageJson = {
+        name: 'test-project',
+        dependencies: {
+          express: '^4.18.0',
+          lodash: '^4.17.21'
+        },
+        devDependencies: {
+          jest: '^29.0.0',
+          eslint: '^8.0.0'
+        }
+      }
+
+      fs.readFile.mockResolvedValue(JSON.stringify(mockPackageJson))
+
+      const packages = await getProjectPackages()
+
+      // Verify result is a flat array (regression test for spread operator fix)
+      expect(Array.isArray(packages)).toBe(true)
+      expect(packages.every((pkg) => typeof pkg === 'string')).toBe(true)
+
+      // Verify all packages are present with correct format
+      expect(packages).toHaveLength(4)
+      expect(packages).toEqual([
+        'express@^4.18.0',
+        'lodash@^4.17.21',
+        'jest@^29.0.0',
+        'eslint@^8.0.0'
+      ])
+    })
+
+    it('should return only dependencies when devDependencies is missing', async () => {
+      const mockPackageJson = {
+        name: 'test-project',
+        dependencies: {
+          express: '^4.18.0',
+          lodash: '^4.17.21'
+        }
+      }
+
+      fs.readFile.mockResolvedValue(JSON.stringify(mockPackageJson))
+
+      const packages = await getProjectPackages()
+
+      expect(Array.isArray(packages)).toBe(true)
+      expect(packages.every((pkg) => typeof pkg === 'string')).toBe(true)
+      expect(packages).toHaveLength(2)
+      expect(packages).toEqual(['express@^4.18.0', 'lodash@^4.17.21'])
+    })
+
+    it('should return only devDependencies when dependencies is missing', async () => {
+      const mockPackageJson = {
+        name: 'test-project',
+        devDependencies: {
+          jest: '^29.0.0',
+          eslint: '^8.0.0'
+        }
+      }
+
+      fs.readFile.mockResolvedValue(JSON.stringify(mockPackageJson))
+
+      const packages = await getProjectPackages()
+
+      expect(Array.isArray(packages)).toBe(true)
+      expect(packages.every((pkg) => typeof pkg === 'string')).toBe(true)
+      expect(packages).toHaveLength(2)
+      expect(packages).toEqual(['jest@^29.0.0', 'eslint@^8.0.0'])
+    })
+
+    it('should return empty array when neither dependencies nor devDependencies exist', async () => {
+      const mockPackageJson = {
+        name: 'test-project',
+        version: '1.0.0'
+      }
+
+      fs.readFile.mockResolvedValue(JSON.stringify(mockPackageJson))
+
+      const packages = await getProjectPackages()
+
+      expect(Array.isArray(packages)).toBe(true)
+      expect(packages).toHaveLength(0)
+      expect(packages).toEqual([])
+    })
+
+    it('should return error object when package.json is not found', async () => {
+      const error = new Error('File not found')
+      error.code = 'ENOENT'
+      fs.readFile.mockRejectedValue(error)
+
+      const result = await getProjectPackages()
+
+      expect(result).toEqual({
+        error: true,
+        message: expect.stringContaining('No package.json found')
+      })
+    })
+
+    it('should return error object when package.json contains invalid JSON', async () => {
+      fs.readFile.mockResolvedValue('{ invalid json }')
+
+      const result = await getProjectPackages()
+
+      expect(result).toEqual({
+        error: true,
+        message: expect.stringContaining('Error reading package.json')
+      })
+    })
+
+    it('should return error object for other file read errors', async () => {
+      const error = new Error('Permission denied')
+      error.code = 'EACCES'
+      fs.readFile.mockRejectedValue(error)
+
+      const result = await getProjectPackages()
+
+      expect(result).toEqual({
+        error: true,
+        message: expect.stringContaining('Error reading package.json')
+      })
+    })
+  })
+})

--- a/lib/helpers/sourcePackages.js
+++ b/lib/helpers/sourcePackages.js
@@ -14,7 +14,7 @@ async function getProjectPackages() {
     if (packageData && packageData.dependencies) {
       packages = [
         ...packages,
-        Object.keys(packageData.dependencies).map((dep) => {
+        ...Object.keys(packageData.dependencies).map((dep) => {
           return `${dep}@${packageData.dependencies[dep]}`
         })
       ]
@@ -22,7 +22,7 @@ async function getProjectPackages() {
     if (packageData && packageData.devDependencies) {
       packages = [
         ...packages,
-        Object.keys(packageData.devDependencies).map((dep) => {
+        ...Object.keys(packageData.devDependencies).map((dep) => {
           return `${dep}@${packageData.devDependencies[dep]}`
         })
       ]


### PR DESCRIPTION
### **User description**
When running `npq` without args on a repo, it only checks prod dependencies. devDependencies can be vulnerable too - install scripts, malicious tooling etc.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/lirantal/npq/issues/399

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->
Checked on a local project with `devDependencies`.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Bug fix


___

### **Description**
- Include devDependencies in package vulnerability checks

- Extend getProjectPackages to scan both prod and dev dependencies

- Prevent vulnerable dev tools and install scripts from being missed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["package.json"] --> B["getProjectPackages()"]
  B --> C["dependencies"]
  B --> D["devDependencies"]
  C --> E["packages array"]
  D --> E
  E --> F["vulnerability check"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sourcePackages.js</strong><dd><code>Add devDependencies scanning to package analysis</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/helpers/sourcePackages.js

<ul><li>Modified <code>getProjectPackages()</code> to extract and include <code>devDependencies</code> <br>alongside <code>dependencies</code><br> <li> Changed packages array initialization to spread operator pattern for <br>combining both dependency types<br> <li> Added conditional check for <code>packageData.devDependencies</code> to safely <br>process dev dependencies<br> <li> Maintains backward compatibility while expanding vulnerability <br>scanning scope</ul>


</details>


  </td>
  <td><a href="https://github.com/lirantal/npq/pull/400/files#diff-84303b72b3e1bb9ef1b2235867e56d04a1c06bf2ac66e14249f81be2807470f4">+14/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

