### PR TITLE
fix: signal detection for malicious packages on osv

### DIFF
--- a/__tests__/marshalls.snyk.test.js
+++ b/__tests__/marshalls.snyk.test.js
@@ -145,6 +145,27 @@ describe('Snyk Marshall', () => {
       expect(fetch).toHaveBeenCalledWith('https://api.osv.dev/v1/query', expect.any(Object))
     })
 
+    it('should throw the same malicious-package error as Snyk when OSV flags malware', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            vulns: [
+              {
+                id: 'MAL-1',
+                summary: 'Malicious code in pkg (npm)',
+                database_specific: { 'malicious-packages-origins': [{}] }
+              }
+            ]
+          })
+      })
+
+      const pkg = { packageName: 'malware-pkg-osv', packageVersion: '1.0.0' }
+      await expect(marshall.validate(pkg)).rejects.toThrow(
+        'Malicious package found: https://snyk.io/vuln/npm:malware-pkg-osv'
+      )
+    })
+
     it('should pass if no vulnerabilities are found by OSV', async () => {
       fetch.mockResolvedValueOnce({
         ok: true,
@@ -175,6 +196,87 @@ describe('Snyk Marshall', () => {
       const result = await marshall.validate(pkg)
 
       expect(result).toEqual({ issuesCount: 0, isMaliciousPackage: false })
+    })
+
+    it('should set isMaliciousPackage when OSV vuln has malicious-packages-origins array', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            vulns: [
+              {
+                id: 'MAL-2026-2452',
+                summary: 'Malicious code in strapi-plugin-blurhash (npm)',
+                database_specific: { 'malicious-packages-origins': [{ source: 'ghsa-malware' }] }
+              }
+            ]
+          })
+      })
+
+      const result = await marshall.getOsvVulnerabilityInfo({
+        packageName: 'strapi-plugin-blurhash',
+        packageVersion: '1.0.0'
+      })
+      expect(result).toEqual({ issuesCount: 1, isMaliciousPackage: true })
+    })
+
+    it('should set isMaliciousPackage when malicious-packages-origins is an empty array', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            vulns: [
+              {
+                id: 'MAL-X',
+                database_specific: { 'malicious-packages-origins': [] }
+              }
+            ]
+          })
+      })
+
+      const result = await marshall.getOsvVulnerabilityInfo({
+        packageName: 'edge-pkg',
+        packageVersion: '1.0.0'
+      })
+      expect(result.isMaliciousPackage).toBe(true)
+    })
+
+    it('should set isMaliciousPackage when OSV summary starts with Malicious (case-insensitive)', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            vulns: [{ id: 'GHSA-x', summary: 'MALICIOUS npm typosquat' }]
+          })
+      })
+
+      const result = await marshall.getOsvVulnerabilityInfo({
+        packageName: 'typosquat-pkg',
+        packageVersion: '1.0.0'
+      })
+      expect(result.isMaliciousPackage).toBe(true)
+    })
+
+    it('should not set isMaliciousPackage for non-malicious OSV vulns', async () => {
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            vulns: [
+              {
+                id: 'GHSA-abc',
+                summary: 'Prototype pollution in foo',
+                database_specific: {}
+              }
+            ]
+          })
+      })
+
+      const result = await marshall.getOsvVulnerabilityInfo({
+        packageName: 'foo',
+        packageVersion: '1.0.0'
+      })
+      expect(result.isMaliciousPackage).toBe(false)
     })
   })
 

--- a/docs/features/malicious-package.md
+++ b/docs/features/malicious-package.md
@@ -1,0 +1,85 @@
+# Malicious package detection
+
+NPQ flags **known-malicious npm packages** as part of the **Supply Chain Security** checks driven by the Snyk marshall (`lib/marshalls/snyk.marshall.js`). Detection uses either the **Snyk API** (when a token is configured) or the **OSV API** (`api.osv.dev`) as a fallback.
+
+## Overview
+
+- The marshall resolves the package version (including `latest`), queries vulnerability data, and may **throw** an error when issues exist.
+- If any reported issue is classified as **malicious**, NPQ throws a dedicated error so the CLI and **`reportResults`** can treat the case differently from ordinary vulnerabilities (single prominent error, warnings suppressed for that package).
+
+## Data sources
+
+| Mode | When | Endpoint / behavior |
+|------|------|---------------------|
+| **Snyk API** | `SNYK_API_TOKEN` or `SNYK_TOKEN` set, or token in `~/.config/configstore/snyk.json` | `GET` to Snyk npm vuln API (URL overridable via `SNYK_API_URL` / `SNYK_API`) |
+| **OSV** | No Snyk token | `POST` to `https://api.osv.dev/v1/query` with `package.name`, `package.ecosystem: "npm"`, and `version` |
+
+Malicious classification is computed from the JSON returned by whichever source is active.
+
+## How “malicious” is determined
+
+### Snyk API response
+
+When `data.vulnerabilities` is present, the package is considered malicious if **any** vulnerability has:
+
+```text
+vulnerability.title === "Malicious Package"
+```
+
+### OSV response
+
+When `data.vulns` is present, **any** single vuln object can mark the package malicious via `isOsvVulnMalicious` logic:
+
+1. **`database_specific["malicious-packages-origins"]`**  
+   If this property exists and its value is an **array** (including an empty array), the vuln counts as malicious. This matches OSV records that tie the advisory to the malicious-packages dataset.
+
+2. **`summary` prefix**  
+   If `summary` is a string and, after lowercasing, it **starts with** `"malicious"`, the vuln counts as malicious. This covers summaries such as “Malicious code in …” regardless of original casing.
+
+If **no** vuln matches, `isMaliciousPackage` is `false`. Fetch/parse failures are treated as no issues (`issuesCount: 0`, `isMaliciousPackage: false`).
+
+## Errors thrown by the marshall
+
+When `issuesCount > 0`:
+
+1. **Malicious (Snyk or OSV)** — checked **first**, regardless of token:
+   - Message: `Malicious package found: https://snyk.io/vuln/npm:<encodedPackageName>`
+   - The Snyk advisory URL is used for both paths so users get a consistent link.
+
+2. **Non-malicious, with Snyk token**  
+   - `N vulnerable path(s) found: https://snyk.io/vuln/npm:<encodedPackageName>`
+
+3. **Non-malicious, OSV only**  
+   - `N vulnerabilities found by OSV for <packageName>`
+
+This alignment matters because reporting does not inspect structured fields on the error; it keys off the message string (see below).
+
+## How reporting treats malicious packages
+
+`lib/helpers/reportResults.js` scans errors for a substring match:
+
+```text
+error.message.includes("Malicious package found")
+```
+
+When that matches **any** error for a package:
+
+- Only that error line is shown for errors on that package (other errors for the same package are not listed individually in the same way as the multi-error path).
+- **Warnings** for that package are **not** printed (`isPackageMalicious` blocks the warnings branch).
+- **Error count** for summary purposes is **1** for that package (malicious is summarized as a single critical outcome).
+
+Other marshall errors (for example messages that say “malicious” in a different wording) do **not** trigger this path unless they contain the exact substring `Malicious package found`.
+
+## Limitations
+
+- Detection depends on **Snyk** and **OSV** coverage; typosquats or novel malware not yet in those databases may not be flagged here.
+- OSV heuristics (`malicious-packages-origins`, summary prefix) may evolve with OSV schema and advisory text; the implementation in `snyk.marshall.js` is the source of truth.
+- Reporting relies on the **error message string**; changing the thrown message without updating `reportResults` would break the special malicious UI.
+
+## Related code
+
+| Area | File |
+|------|------|
+| Vulnerability + malicious logic | `lib/marshalls/snyk.marshall.js` |
+| Console / plain summary output | `lib/helpers/reportResults.js` |
+| Tests (Snyk/OSV + reporting) | `__tests__/marshalls.snyk.test.js`, `__tests__/reportResults.test.js` |

--- a/lib/marshalls/snyk.marshall.js
+++ b/lib/marshalls/snyk.marshall.js
@@ -9,6 +9,30 @@ const { marshallCategories } = require('./constants')
 const MARSHALL_NAME = 'snyk'
 const SNYK_PACKAGE_PAGE = 'https://snyk.io/vuln/npm:'
 const SNYK_CONFIG_FILE = '.config/configstore/snyk.json'
+const OSV_MALICIOUS_ORIGINS_KEY = 'malicious-packages-origins'
+
+function isOsvVulnMalicious(vuln) {
+  if (!vuln || typeof vuln !== 'object') {
+    return false
+  }
+
+  const ds = vuln.database_specific
+  if (ds && typeof ds === 'object' && !Array.isArray(ds)) {
+    if (Object.prototype.hasOwnProperty.call(ds, OSV_MALICIOUS_ORIGINS_KEY)) {
+      const origins = ds[OSV_MALICIOUS_ORIGINS_KEY]
+      if (Array.isArray(origins)) {
+        return true
+      }
+    }
+  }
+
+  const summary = vuln.summary
+  if (typeof summary === 'string' && summary.toLowerCase().startsWith('malicious')) {
+    return true
+  }
+
+  return false
+}
 
 class Marshall extends BaseMarshall {
   constructor(options) {
@@ -55,18 +79,14 @@ class Marshall extends BaseMarshall {
         }
 
         if (data.issuesCount && data.issuesCount > 0) {
-          if (this.snykApiToken) {
-            const packageSecurityInfo = `${SNYK_PACKAGE_PAGE}${encodeURIComponent(pkg.packageName)}`
-            if (data.isMaliciousPackage) {
-              throw new Error(`Malicious package found: ${packageSecurityInfo}`)
-            }
-
-            throw new Error(`${data.issuesCount} vulnerable path(s) found: ${packageSecurityInfo}`)
-          } else {
-            throw new Error(
-              `${data.issuesCount} vulnerabilities found by OSV for ${pkg.packageName}`
-            )
+          const packageSecurityInfo = `${SNYK_PACKAGE_PAGE}${encodeURIComponent(pkg.packageName)}`
+          if (data.isMaliciousPackage) {
+            throw new Error(`Malicious package found: ${packageSecurityInfo}`)
           }
+          if (this.snykApiToken) {
+            throw new Error(`${data.issuesCount} vulnerable path(s) found: ${packageSecurityInfo}`)
+          }
+          throw new Error(`${data.issuesCount} vulnerabilities found by OSV for ${pkg.packageName}`)
         }
 
         return data
@@ -93,12 +113,7 @@ class Marshall extends BaseMarshall {
       .then((response) => response.json())
       .then((data) => {
         if (data && data.vulns) {
-          const isMaliciousPackage = data.vulns.some(
-            (vuln) =>
-              vuln.database_specific &&
-              vuln.database_specific['malicious-packages-origins'] &&
-              vuln.database_specific['malicious-packages-origins'].length > 0
-          )
+          const isMaliciousPackage = data.vulns.some((vuln) => isOsvVulnMalicious(vuln))
 
           return {
             issuesCount: data.vulns.length,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Snyk found malicious package works fine with a token but without a token it would resort back to OSV which didn't properly bubble up the malicious package signal. This PR fixes it.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- Unit tests are expected for all changes. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the documentation (if required).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
