### PR TITLE
chore: align automerge workflow and add automerge-label provisioning

### DIFF
--- a/.github/workflows/repo-init.yml
+++ b/.github/workflows/repo-init.yml
@@ -1,0 +1,26 @@
+name: Repository init
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/repo-init.yml'  # only fires when this file itself changes
+  schedule:
+    - cron: '0 9 * * 1'   # Every Monday at 09:00 UTC
+
+jobs:
+  create-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create automerge label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "automerge" \
+            --repo "${{ github.repository }}" \
+            --color "0075ca" \
+            --description "Merge this PR automatically once checks pass" \
+            --force


### PR DESCRIPTION
Two related housekeeping changes for the dependabot/automerge setup:

1. **`automerge.yml`** — set `MERGE_LABELS: "automerge"`. The `pascalgn/automerge-action` requires *all* labels listed in `MERGE_LABELS` to be present on a PR, not any of them — so listing more than one label here means PRs need every label to auto-merge. Keeping just `automerge` is what we actually want.
2. **`repo-init.yml`** (new file) — provisions the `automerge` label in this repo on a weekly schedule (and on first run via `workflow_dispatch`), so dependabot PRs that get the label can be auto-merged without manual setup per repo.

If `automerge.yml` is already set to `MERGE_LABELS: "automerge"` for this repo, only `repo-init.yml` is added.