### PR TITLE
Fix 404 link to Tao Bojlén's npm trust article

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here's a screenshot of npq in action:
 Media coverage about npq:
 
 - As mentioned on [Thomas Gentilhomme](https://github.com/fraxken)'s French book of [Become a Node.js Developer](https://docs.google.com/document/d/1JHgmEFkc8Py4XSuCB8_DQ5FFEJoogyeninFK6ucTd4o/edit#)
-- Tao Bojlén's [A web of trust for npm](https://www.btao.org/2020/10/02/npm-trust.html)
+- Tao Bojlén's [A web of trust for npm](https://btao.org/posts/2020-10-02-npm-trust/)
 - Zander's [favorite list of command line tools](https://zander.wtf/blog/terminal-commands)
 - Ran Bar Zik's [npq review to install safe modules](https://internet-israel.com/%D7%A4%D7%99%D7%AA%D7%95%D7%97-%D7%90%D7%99%D7%A0%D7%98%D7%A8%D7%A0%D7%98/%D7%91%D7%A0%D7%99%D7%99%D7%AA-%D7%90%D7%AA%D7%A8%D7%99-%D7%90%D7%99%D7%A0%D7%98%D7%A8%D7%A0%D7%98-%D7%9C%D7%9E%D7%A4%D7%AA%D7%97%D7%99%D7%9D/%D7%91%D7%93%D7%99%D7%A7%D7%94-%D7%A2%D7%9D-npq-%D7%9B%D7%93%D7%99-%D7%9C%D7%95%D7%95%D7%93%D7%90-%D7%94%D7%AA%D7%A7%D7%A0%D7%94-%D7%AA%D7%A7%D7%99%D7%A0%D7%94-%D7%A9%D7%9C-%D7%9E%D7%95%D7%93%D7%95/)
 - ostechnix's [How To Safely Install Packages Using Npm Or Yarn On Linux](https://ostechnix.com/how-to-safely-install-packages-using-npm-or-yarn-on-linux)


### PR DESCRIPTION
Just a 404 fix in the README file.

## Description
Updated the link to Tao Bojlén's article on npm trust, link structure of the site is probably changed. Old link goes to 404.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
No related issue.

## Motivation and Context
A 404 link in a security tool's README.md sends a bad signal. Wouldn't have bothered otherwise. 

## How Has This Been Tested?
No test necessary.

## Checklist:
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix broken link in README to Tao Bojlén’s “A web of trust for npm” by updating to https://btao.org/posts/2020-10-02-npm-trust/. Prevents a 404 and keeps the docs accurate.

<sup>Written for commit 9a7356a0bbb65a652ac020eec863c219ad876de7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

