### PR TITLE
docs: add repository context docs 🤖🤖🤖

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,35 @@
-# Agent Guidance
+# AGENTS.md
 
-## Project Overview
+Guidance for AI coding agents working in this repository.
 
-`npq` is a Node.js CLI that audits npm package installs before handing off to the package manager. The main executables live in `bin/npq.js` and `bin/npq-hero.js`; shared implementation code lives under `lib/`.
+## Start Here
 
-## Repository Map
+Before making changes, read:
 
-- `bin/` contains the CLI entry points.
-- `lib/marshalls/` contains the security checks that inspect package metadata, vulnerabilities, signatures, provenance, and related signals.
-- `lib/helpers/` contains shared helper modules for registry access, prompts, reporting, repository parsing, and utility logic.
-- `__tests__/` contains the Jest test suite.
-- `docs/` contains project documentation. Feature-specific docs belong in `docs/feature/` using the singular directory name.
-- `scripts/` contains release/build/support scripts.
+- `CONTRIBUTING.md` for contribution, PR, testing, commit, and agent-specific expectations.
+- `RELEASE.md` for release workflow details.
+- `README.md` for user-facing behavior, install/use examples, and package or app overview.
+- `docs/README.md` for the project documentation index.
+- `docs/development.md` for local setup and development workflows.
+- `docs/testing.md` for test strategy, commands, and verification expectations.
+- `docs/architecture.md` for project structure, boundaries, and important invariants.
+- `docs/conventions.md` for project-specific coding, documentation, and maintenance conventions.
 
-## Development Commands
+Treat those files as the source of truth. Do not duplicate or reinterpret their rules here.
 
-- Install dependencies with `npm install`.
-- Run tests with `npm test` or `npm run test`.
-- Run a focused Jest test with `npx jest __tests__/file.test.js`.
-- Run linting with `npm run lint`.
-- Run formatting for JavaScript files with `npm run format`.
-- Run the build script with `npm run build`.
+## Documentation
 
-The project requires Node.js `>=20.13.0`.
+- Keep documentation in sync when changing behavior, public interfaces, workflows, architecture, configuration, or operational assumptions.
+- Put project-specific development details in `docs/`; keep root files focused on their standard audiences.
+- Prefer linking to the source of truth over duplicating long instructions across files.
+- When adding new docs, link them from `docs/README.md` and update this file only when they become important entry points for future agents.
 
-## Working Conventions
+## PRs and Issues
 
-- Prefer existing CommonJS patterns (`require`, `module.exports`) unless a file already uses a different style.
-- Keep marshall behavior covered by focused tests in `__tests__/marshalls.*.test.js` when changing security checks.
-- When changing CLI behavior, check both `bin/npq.js` and `bin/npq-hero.js` for differences in audit-only, install, prompt, and package-manager passthrough flows.
-- When adding or moving feature documentation, place it in `docs/feature/` and update `docs/README.md` if it should appear in the docs index.
-- Avoid committing generated coverage output unless the task explicitly asks for it.
+- Follow PR, issue, and agent-labeling rules in `CONTRIBUTING.md`.
+- Use the issue-linking format specified in `CONTRIBUTING.md`.
+
+## Releases
+
+- Follow `RELEASE.md` for release workflow and changeset creation steps.
+- If this project uses changesets, treat `RELEASE.md` and any changeset guidance in `CONTRIBUTING.md` as authoritative.

--- a/README.md
+++ b/README.md
@@ -257,6 +257,10 @@ When auto-continue is disabled, npq will always prompt for explicit confirmation
 
 * This is not telemetry. NPQ does not collect any usage data. When auditing a package, NPQ fetches the maintainers/authors of the dependency and checks their email addresses to verify they are valid and not associated with expired domains. Expired domains can be abused by attackers for account takeover (ATO) attacks to compromise packages with malicious versions. Hence, NPQ may make DNS requests to domains like `gmail.com` or personal domains found in maintainer emails. Additionally, NPQ makes HTTP requests to `osv.dev` to fetch security vulnerability data (or uses Snyk if configured, as a prioritized option).
 
+## Documentation
+
+- [Project documentation](./docs/README.md) - development, testing, architecture, and conventions.
+
 ## Contributing
 
 Please consult the [CONTRIBUTING](CONTRIBUTING.md) for guidelines on contributing to this project

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,22 @@
+# Release
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning and release notes.
+
+## Release Flow
+
+1. Ensure all intended changes are merged and CI is green.
+2. Run `npm run version` to apply Changesets version and changelog updates.
+3. Review the generated package and changelog changes.
+4. Run the release command, if configured for the repository.
+
+No root `release` script is currently defined. Use the repository's publishing workflow or add one before publishing.
+
+## Changesets
+
+Add a changeset for user-facing package behavior changes:
+
+```sh
+npm run changeset
+```
+
+Documentation-only, test-only, and internal refactor PRs usually do not need a changeset unless they describe or accompany a release-worthy behavior change.

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,3 +73,10 @@ When adding new features or making significant changes:
 | Exit Codes | `feature/exit-codes.md` | CLI and package-manager passthrough exit behavior |
 | Malicious Packages | `feature/malicious-package.md` | Known-malicious package detection and reporting |
 | Dependency Reduction | `feature/pacote-dependency-reduction.md` | Optional dependency management |
+
+## Project context
+
+- [Development](./development.md) - local setup, workflows, and useful commands.
+- [Testing](./testing.md) - test commands, test organization, and verification expectations.
+- [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
+- [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,18 @@
+# Architecture
+
+## Overview
+
+npq package description: marshall your npm/npm package installs with high quality and class 🎖.
+
+## Repository Structure
+
+- `package.json` - root package scripts and dependency metadata.
+- `.changeset/` - Changesets configuration and pending release notes.
+- `docs/` - project documentation for maintainers and coding agents.
+
+## Boundaries
+
+- Keep user-facing usage, installation, and examples in the root `README.md`.
+- Keep contribution rules in `CONTRIBUTING.md`.
+- Keep release workflow details in `RELEASE.md`.
+- Keep deeper development and architecture notes in `docs/`.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,20 @@
+# Conventions
+
+## Commits and PRs
+
+- Use Conventional Commits for commit messages.
+- Keep PRs focused on one logical change.
+- Include a Changeset for release-worthy package behavior changes.
+- Agent-authored PRs should follow the repository's agent title marker guidance in `CONTRIBUTING.md`.
+
+## Documentation
+
+- Keep root `README.md` focused on users and package consumers.
+- Put maintainer and agent context in `docs/`.
+- Link new documentation from `docs/README.md`.
+
+## Code
+
+- Prefer the existing package structure and scripts over introducing new tooling.
+- Keep generated files, dependency folders, and build output out of commits.
+- Match formatting and lint expectations already configured in the repository.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,23 @@
+# Development
+
+## Prerequisites
+
+- Node.js compatible with this repository's packages and tooling.
+- npm for dependency installation and scripts.
+
+## Setup
+
+```sh
+npm install
+```
+
+## Common Commands
+
+- `pnpm build` - builds the project.
+- `pnpm lint` - runs lint checks.
+- `pnpm test` - runs the test suite.
+- `pnpm format` - formats supported files.
+
+## Repository Notes
+
+This repository is organized around the root package `npq`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,24 @@
+# Testing
+
+## Test Command
+
+Run the test suite with:
+
+```sh
+npm run test
+```
+
+## Linting
+
+Run lint checks with:
+
+```sh
+npm run lint
+```
+
+
+## Expectations
+
+- Add or update tests for behavior changes.
+- Run the relevant package-level checks before opening a PR.
+- Keep generated coverage, build output, and dependency folders out of commits.


### PR DESCRIPTION
Adds standardized repository context for coding agents and maintainers:

- refreshes AGENTS.md with the shared routing template
- adds or links canonical docs for development, testing, architecture, and conventions
- adds RELEASE.md where missing for Changesets release guidance

No package behavior changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds standardized repository context docs for `npq` to guide coding agents and maintainers. Updates `AGENTS.md`, adds `RELEASE.md` (Changesets workflow), and introduces/links `docs/architecture.md`, `docs/development.md`, `docs/testing.md`, and `docs/conventions.md`, with a docs index link in `README.md`; no behavior changes.

<sup>Written for commit 2a0821c68b70d2758c864f7b847ae68c5e9d59bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/430?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

