### PR TITLE
[codex] Remove npm-high-impact install dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "jest": "^30.3.0",
         "lint-staged": "^16.4.0",
         "lockfile-lint": "^5.0.0",
-        "npm-high-impact": "^1.13.0",
         "prettier": "^3.6.2",
         "semantic-release": "24.2.9"
       },
@@ -7418,17 +7417,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm-high-impact": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/npm-high-impact/-/npm-high-impact-1.13.0.tgz",
-      "integrity": "sha512-Dngjb2fyZfj4/7aZ+9kGGGK/IWnBhb45nzHX1ECxi26vXixkKzdixCB81XTwQzyAwc4d39VbcTL+rlS+d7VETA==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/npm-package-arg": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "jest": "^30.3.0",
     "lint-staged": "^16.4.0",
     "lockfile-lint": "^5.0.0",
-    "npm-high-impact": "^1.13.0",
     "prettier": "^3.6.2",
     "semantic-release": "24.2.9"
   },

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -4,10 +4,45 @@ const fs = require('fs/promises')
 const path = require('path')
 
 const TOP_PACKAGES_FILE_PATH = path.join(__dirname, '../data/top-packages.json')
+const NPM_HIGH_IMPACT_TOP_PACKAGES_URL = 'https://unpkg.com/npm-high-impact@1.13.0/lib/top.js'
+const TOP_PACKAGES_EXPORT_PATTERN = /^export const top = \[\n([\s\S]*)\n\]\n?$/
+const TOP_PACKAGE_NAME_PATTERN = /^[ ]{2}'([^'\\]+)',?$/
+
+function parseTopPackages(source) {
+  const topPackagesExport = source.match(TOP_PACKAGES_EXPORT_PATTERN)
+
+  if (!topPackagesExport) {
+    throw new Error('Unexpected npm-high-impact top packages export format')
+  }
+
+  const topPackages = topPackagesExport[1].split('\n').map((line) => {
+    const packageName = line.match(TOP_PACKAGE_NAME_PATTERN)
+
+    if (!packageName) {
+      throw new Error(`Unexpected npm-high-impact package entry: ${line}`)
+    }
+
+    return packageName[1]
+  })
+
+  if (topPackages.length === 0) {
+    throw new Error('npm-high-impact top packages export is empty')
+  }
+
+  return [...new Set(topPackages)]
+}
 
 async function downloadTopPackages() {
-  const { npmHighImpact } = await import('npm-high-impact')
-  return [...new Set(npmHighImpact)]
+  // Keep this pinned to a published npm-high-impact artifact for reproducible builds.
+  const response = await fetch(NPM_HIGH_IMPACT_TOP_PACKAGES_URL)
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to download npm-high-impact top packages: ${response.status} ${response.statusText}`
+    )
+  }
+
+  return parseTopPackages(await response.text())
 }
 
 async function saveTopPackagesToFile() {


### PR DESCRIPTION
## Summary

- removes `npm-high-impact` from the installed dev dependency graph
- keeps the generated `data/top-packages.json` runtime dataset from the #431 fix unchanged
- updates `npm run build` to fetch the pinned `npm-high-impact@1.13.0` generated `lib/top.js` file at build time and parse it strictly

## Why

The previous PR replaced stale `npm-rank` data with the fresher `npm-high-impact` corpus, which fixed false typosquatting reports for packages like `oxlint`. This follow-up keeps that corpus but avoids adding another package to npq's install graph. Maintainers only need the network fetch when intentionally regenerating the checked-in dataset.

## Validation

- `npx --yes npm@11.10.0 run build`
- `git diff --exit-code -- data/top-packages.json`
- `npx --yes npm@11.10.0 exec -- jest __tests__/marshalls.typosquatting.test.js --coverage=false`
- `npx --yes npm@11.10.0 test`
- `npx --yes npm@11.10.0 run lint`
- `git diff --check`

## Related issues

Refs: #431


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `npm-high-impact` from devDependencies and now fetch the top-packages dataset during build from a pinned unpkg URL. This reduces install footprint and keeps builds reproducible.

- **Refactors**
  - Replaced `import('npm-high-impact')` with an HTTP fetch to a pinned `unpkg` artifact in `scripts/build.js`, plus a small parser to extract, validate, and dedupe package names.
  - Added clear error messages for fetch failures and unexpected export formats.

- **Dependencies**
  - Removed `npm-high-impact` from `package.json` and the lockfile.

<sup>Written for commit ff2d0e1f2624be6a1a89e2f2acfbce1b78147ede. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

