### PR TITLE
feat: support authenticated custom registries 🤖🤖🤖

### DIFF
--- a/.changeset/bright-tools-audit.md
+++ b/.changeset/bright-tools-audit.md
@@ -1,0 +1,6 @@
+---
+'npq': minor
+---
+
+Add authenticated default and scoped custom-registry support using standard npm configuration, with explicit reporting when optional registry services cannot be evaluated.
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ logs
 *.log
 npm-debug.log*
 node_modules
+.worktrees/
 
 # Coverage
 lib-cov

--- a/README.md
+++ b/README.md
@@ -78,6 +78,16 @@ brew install npq
 npq install express
 ```
 
+### Custom registries
+
+NPQ reads standard npm registry configuration, including default and scoped registries, authentication, proxies, and TLS settings. You can also select a registry on the command line; the option is shared with the package manager used for installation:
+
+```sh
+npq install @company/tool --registry=https://artifactory.example.com/artifactory/api/npm/npm-virtual/
+```
+
+See [Custom registries](docs/feature/custom-registry.md) for `.npmrc` examples, configuration precedence, private CA setup, skipped capability behavior, and NPQ's no-fallback privacy guarantee.
+
 ### Embed in your day to day
 
 Since `npq` is a pre-step to ensure that the npm package you're installing is safe, you can safely embed it in your day-to-day `npm` usage so there's no need to remember to run `npq` explicitly.
@@ -130,15 +140,15 @@ Note: `npq` by default will offload all commands and their arguments to the `npm
 | --- | --- | ---
 | age | Will show a warning for a package if its age on npm is less than 22 days | Checks a package creation date, not a specific version
 | author | Validates the resolved version’s publisher (`_npmUser`), flags a **new** maintainer on the package (first publish by that email within 21 days), **dormant maintainer** gaps (warning if over ~6 months since their last publish on that package, error if over ~9 months), and very **recent** publishes | See [docs/feature/author-marshall.md](docs/feature/author-marshall.md)
-| downloads | Will show a warning for a package if its download count in the last month is less than 20
+| downloads | Will show a warning for a package if its download count in the last month is less than 20 | Reports `not evaluated` for custom-registry packages instead of querying the public npm downloads service
 | readme | Will show a warning if a package has no README or it has been detected as a security placeholder package by npm staff
 | repo | Will show a warning if a package has been found without a valid and working repository URL | Checks the latest version for a repository URL
 | scripts | Will show a warning if a package has a pre/post install script which could potentially be malicious
 | snyk | Will show a warning if a package has been found with vulnerabilities in Snyk's database | For Snyk to work you need to either have the `snyk` npm package installed with a valid API token, or make the token available in the `SNYK_TOKEN` environment variable, and npq will use it
 | license | Will show a warning if a package has been found without a license field | Checks the latest version for a license
 | expired domains | Will show a warning if a package has been found with one of its maintainers having an email address that includes an expired domain | Checks a dependency version for a maintainer with an expired domain
-| signatures | Will compare the package's signature as it shows on the registry's pakument with the keys published on the npmjs.com registry
-| provenance | Will verify the package's attestations of provenance metadata for the published package, and **error** on [provenance regression](docs/feature/provenance.md) (an older semver had registry provenance metadata but the version you install does not)
+| signatures | Will compare the package's signature as it shows on the registry's packument with signing keys published by the selected registry | Reports `not evaluated` if the selected registry does not expose signing keys
+| provenance | Will verify the package's attestations of provenance metadata for the published package, and **error** on [provenance regression](docs/feature/provenance.md) (an older semver had registry provenance metadata but the version you install does not) | Reports `not evaluated` if the selected registry does not expose signing keys or attestations
 | version-maturity | Will show a warning if the specific version being installed was published less than 7 days ago | Helps identify recently published versions that may not have been reviewed by the community yet
 | newBin | Will show a warning if the package version being installed introduces a new command-line binary (via the `bin` field in `package.json`) that was not present in its previous version. | Helps identify potentially unexpected new executables being added to your `node_modules/.bin/` directory.
 | typosquatting | Will show a warning if the package name is similar to a popular package name, which could indicate a potential typosquatting attack. | Helps identify packages that may be trying to trick users into installing them by mimicking popular package names.

--- a/__tests__/__fixtures__/fatalRegistry.marshall.js
+++ b/__tests__/__fixtures__/fatalRegistry.marshall.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const BaseMarshall = require('../../lib/marshalls/baseMarshall')
+const { RegistryError } = require('../../lib/helpers/registryErrors')
+
+class FatalRegistryMarshall extends BaseMarshall {
+  constructor(options) {
+    super(options)
+    this.name = 'fatal-registry'
+  }
+
+  title() {
+    return 'Testing fatal registry propagation'
+  }
+
+  validate() {
+    return Promise.reject(
+      new RegistryError('Registry network request failed', {
+        registry: 'https://artifactory.example.test/api/npm/npm/',
+        code: 'EREGISTRYNETWORK'
+      })
+    )
+  }
+}
+
+module.exports = FatalRegistryMarshall

--- a/__tests__/cli.parser.complete.test.js
+++ b/__tests__/cli.parser.complete.test.js
@@ -199,6 +199,23 @@ describe('CliParser', () => {
   })
 
   describe('parseArgsFull', () => {
+    test('returns standard registry configuration arguments', () => {
+      mockParseArgs.mockReturnValue({
+        values: {
+          registry: 'https://artifactory.example.test/api/npm/npm/',
+          userconfig: '/tmp/user.npmrc',
+          globalconfig: '/tmp/global.npmrc'
+        },
+        positionals: ['install', '@company/tool']
+      })
+
+      expect(CliParser.parseArgsFull().registryConfigArgs).toEqual([
+        '--registry=https://artifactory.example.test/api/npm/npm/',
+        '--userconfig=/tmp/user.npmrc',
+        '--globalconfig=/tmp/global.npmrc'
+      ])
+    })
+
     test('should display help when --help flag is provided', () => {
       mockParseArgs.mockReturnValue({
         values: { help: true },
@@ -243,6 +260,7 @@ describe('CliParser', () => {
         dryRun: true,
         plain: true,
         disableAutoContinue: false,
+        registryConfigArgs: [],
         installSubcommandExplicit: true
       })
     })
@@ -409,6 +427,19 @@ describe('CliParser', () => {
   })
 
   describe('parseArgsMinimal', () => {
+    test('returns standard registry configuration arguments', () => {
+      mockParseArgs.mockReturnValue({
+        values: {
+          registry: 'https://artifactory.example.test/api/npm/npm/'
+        },
+        positionals: ['install', '@company/tool']
+      })
+
+      expect(CliParser.parseArgsMinimal().registryConfigArgs).toEqual([
+        '--registry=https://artifactory.example.test/api/npm/npm/'
+      ])
+    })
+
     test('should extract packages with install command', () => {
       mockParseArgs.mockReturnValue({
         positionals: ['install', 'express', 'lodash']
@@ -417,7 +448,8 @@ describe('CliParser', () => {
       const result = CliParser.parseArgsMinimal()
 
       expect(result).toEqual({
-        packages: ['express@latest', 'lodash@latest']
+        packages: ['express@latest', 'lodash@latest'],
+        registryConfigArgs: []
       })
     })
 
@@ -429,7 +461,8 @@ describe('CliParser', () => {
       const result = CliParser.parseArgsMinimal()
 
       expect(result).toEqual({
-        packages: []
+        packages: [],
+        registryConfigArgs: []
       })
     })
 
@@ -441,7 +474,8 @@ describe('CliParser', () => {
       const result = CliParser.parseArgsMinimal()
 
       expect(result).toEqual({
-        packages: []
+        packages: [],
+        registryConfigArgs: []
       })
     })
   })
@@ -490,6 +524,7 @@ describe('CliParser', () => {
         dryRun: true,
         plain: true,
         disableAutoContinue: false,
+        registryConfigArgs: [],
         installSubcommandExplicit: true
       })
     })
@@ -513,6 +548,7 @@ describe('CliParser', () => {
         dryRun: true,
         plain: true,
         disableAutoContinue: true,
+        registryConfigArgs: [],
         installSubcommandExplicit: true
       })
     })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -63,6 +63,10 @@ describe('npq CLI script', () => {
     Spinner.mockClear()
   })
 
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
   test('should initialize and start spinner in interactive mode without --plain flag', async () => {
     // Arrange
     const { CliParser } = require('../lib/cli')
@@ -209,7 +213,6 @@ describe('npq CLI script', () => {
     expect(cliPrompt.autoContinue).not.toHaveBeenCalled()
     expect(pkgMgr.process).toHaveBeenCalledWith('pnpm')
 
-    consoleLog.mockRestore()
   })
 
   test('still follows warning behavior when skipped checks accompany a warning', async () => {
@@ -241,6 +244,5 @@ describe('npq CLI script', () => {
     expect(consoleLog).toHaveBeenCalledWith('Packages with issues found:')
     expect(cliPrompt.autoContinue).toHaveBeenCalled()
 
-    consoleLog.mockRestore()
   })
 })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -28,6 +28,14 @@ jest.mock('../lib/helpers/cliSpinner', () => ({
 jest.mock('../lib/helpers/sourcePackages', () => ({
   getProjectPackages: jest.fn().mockResolvedValue(['express'])
 }))
+const mockRegistryConfig = { requestOptions: {} }
+const mockRegistryClientInstance = { registryFor: jest.fn() }
+jest.mock('../lib/helpers/registryConfig', () => ({
+  load: jest.fn().mockResolvedValue(mockRegistryConfig)
+}))
+jest.mock('../lib/helpers/registryClient', () =>
+  jest.fn().mockImplementation(() => mockRegistryClientInstance)
+)
 jest.mock('../lib/marshall', () =>
   jest.fn(() => ({
     process: jest.fn().mockResolvedValue({})
@@ -108,5 +116,63 @@ describe('npq CLI script', () => {
     // Assert
     expect(Spinner).not.toHaveBeenCalled()
     expect(mockSpinnerInstance.start).not.toHaveBeenCalled()
+  })
+
+  test('loads and injects registry configuration before auditing', async () => {
+    const { CliParser } = require('../lib/cli')
+    const RegistryConfig = require('../lib/helpers/registryConfig')
+    const RegistryClient = require('../lib/helpers/registryClient')
+    const Marshall = require('../lib/marshall')
+
+    CliParser.parseArgsFull.mockReturnValue({
+      packages: ['@company/tool'],
+      plain: true,
+      dryRun: true,
+      registryConfigArgs: [
+        '--registry=https://artifactory.example.test/api/npm/npm/'
+      ]
+    })
+
+    require('../bin/npq.js')
+    await new Promise(setImmediate)
+
+    expect(RegistryConfig.load).toHaveBeenCalledWith({
+      argv: ['--registry=https://artifactory.example.test/api/npm/npm/']
+    })
+    expect(RegistryClient).toHaveBeenCalledWith(mockRegistryConfig)
+    expect(Marshall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        registryClient: mockRegistryClientInstance
+      })
+    )
+  })
+
+  test('exits without auditing when registry configuration fails', async () => {
+    const { CliParser } = require('../lib/cli')
+    const RegistryConfig = require('../lib/helpers/registryConfig')
+    const Marshall = require('../lib/marshall')
+    const pkgMgr = require('../lib/packageManager')
+    RegistryConfig.load.mockRejectedValueOnce(
+      Object.assign(new Error('Invalid npm registry configuration'), {
+        code: 'EREGISTRYCONFIG'
+      })
+    )
+    CliParser.parseArgsFull.mockReturnValue({
+      packages: ['@company/tool'],
+      plain: true,
+      dryRun: true,
+      registryConfigArgs: []
+    })
+
+    require('../bin/npq.js')
+    await new Promise(setImmediate)
+
+    expect(CliParser.exit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Invalid npm registry configuration'
+      })
+    )
+    expect(Marshall).not.toHaveBeenCalled()
+    expect(pkgMgr.process).not.toHaveBeenCalled()
   })
 })

--- a/__tests__/cli.test.js
+++ b/__tests__/cli.test.js
@@ -175,4 +175,72 @@ describe('npq CLI script', () => {
     expect(Marshall).not.toHaveBeenCalled()
     expect(pkgMgr.process).not.toHaveBeenCalled()
   })
+
+  test('prints skipped checks and continues an explicit install without prompting', async () => {
+    const { CliParser } = require('../lib/cli')
+    const { reportResults } = require('../lib/helpers/reportResults')
+    const cliPrompt = require('../lib/helpers/cliPrompt.js')
+    const pkgMgr = require('../lib/packageManager')
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    CliParser.parseArgsFull.mockReturnValue({
+      packages: ['@company/tool'],
+      packageManager: 'pnpm',
+      plain: true,
+      dryRun: false,
+      disableAutoContinue: false,
+      installSubcommandExplicit: true
+    })
+    reportResults.mockReturnValue({
+      countErrors: 0,
+      countWarnings: 0,
+      countNotEvaluated: 2,
+      resultsForPlainTextPrint: 'skipped-plain',
+      summaryForPlainTextPrint: 'summary-plain',
+      useRichFormatting: false
+    })
+
+    require('../bin/npq.js')
+    await new Promise(setImmediate)
+
+    expect(consoleLog).toHaveBeenCalledWith('Package checks not evaluated:')
+    expect(consoleLog).toHaveBeenCalledWith('skipped-plain')
+    expect(cliPrompt.prompt).not.toHaveBeenCalled()
+    expect(cliPrompt.autoContinue).not.toHaveBeenCalled()
+    expect(pkgMgr.process).toHaveBeenCalledWith('pnpm')
+
+    consoleLog.mockRestore()
+  })
+
+  test('still follows warning behavior when skipped checks accompany a warning', async () => {
+    const { CliParser } = require('../lib/cli')
+    const { reportResults } = require('../lib/helpers/reportResults')
+    const cliPrompt = require('../lib/helpers/cliPrompt.js')
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    CliParser.parseArgsFull.mockReturnValue({
+      packages: ['@company/tool'],
+      packageManager: 'npm',
+      plain: true,
+      dryRun: false,
+      disableAutoContinue: false,
+      installSubcommandExplicit: true
+    })
+    reportResults.mockReturnValue({
+      countErrors: 0,
+      countWarnings: 1,
+      countNotEvaluated: 2,
+      resultsForPlainTextPrint: 'mixed-plain',
+      summaryForPlainTextPrint: 'summary-plain',
+      useRichFormatting: false
+    })
+
+    require('../bin/npq.js')
+    await new Promise(setImmediate)
+
+    expect(consoleLog).toHaveBeenCalledWith('Packages with issues found:')
+    expect(cliPrompt.autoContinue).toHaveBeenCalled()
+
+    consoleLog.mockRestore()
+  })
 })

--- a/__tests__/customRegistry.integration.test.js
+++ b/__tests__/customRegistry.integration.test.js
@@ -1,0 +1,230 @@
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const Marshall = require('../lib/marshall')
+const Marshalls = require('../lib/marshalls')
+const NpmRegistry = require('../lib/helpers/npmRegistry')
+const RegistryConfig = require('../lib/helpers/registryConfig')
+const RegistryClient = require('../lib/helpers/registryClient')
+
+const registryMarshalls = [
+  path.join(process.cwd(), 'lib/marshalls/signatures.marshall.js'),
+  path.join(process.cwd(), 'lib/marshalls/provenance.marshall.js'),
+  path.join(process.cwd(), 'lib/marshalls/downloads.marshall.js')
+]
+
+function responseFor(requestPath, options) {
+  const packageName = options.spec
+  if (requestPath === '-/npm/v1/keys') {
+    return { keys: [{ keyid: 'key-1', key: 'PUBLICKEY' }] }
+  }
+  if (requestPath.startsWith('-/npm/v1/attestations/')) {
+    return { attestations: [{ bundle: {} }] }
+  }
+
+  return {
+    name: packageName,
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': {
+        name: packageName,
+        version: '1.0.0',
+        dist: {
+          integrity: 'sha512-example',
+          signatures: [{ keyid: 'key-1', sig: 'signature' }],
+          attestations: {
+            url: `https://registry.npmjs.org/-/npm/v1/attestations/${packageName}@1.0.0`
+          }
+        }
+      }
+    }
+  }
+}
+
+describe('authenticated custom registry audits', () => {
+  let root
+  let project
+  let home
+  let userConfig
+  let globalConfig
+  let env
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'npq-custom-registry-'))
+    project = path.join(root, 'project')
+    home = path.join(root, 'home')
+    userConfig = path.join(root, 'user.npmrc')
+    globalConfig = path.join(root, 'global.npmrc')
+    fs.mkdirSync(project)
+    fs.mkdirSync(home)
+    fs.writeFileSync(path.join(project, 'package.json'), '{"name":"fixture"}')
+    fs.writeFileSync(userConfig, '')
+    fs.writeFileSync(globalConfig, '')
+    fs.writeFileSync(
+      path.join(project, '.npmrc'),
+      [
+        'registry=https://artifactory.example.test/artifactory/api/npm/npm/',
+        '@company:registry=https://artifactory.example.test/artifactory/api/npm/company/',
+        '//artifactory.example.test/artifactory/api/npm/:_authToken=${ARTIFACTORY_TOKEN}',
+        'strict-ssl=true'
+      ].join('\n')
+    )
+    env = {
+      ...process.env,
+      HOME: home,
+      ARTIFACTORY_TOKEN: 'integration-secret',
+      npm_config_userconfig: userConfig,
+      npm_config_globalconfig: globalConfig
+    }
+    jest.spyOn(Marshalls, 'collectMarshalls').mockResolvedValue(registryMarshalls)
+    jest
+      .spyOn(NpmRegistry.prototype, 'verifySignatures')
+      .mockResolvedValue({ _signatures: [{}] })
+    jest
+      .spyOn(NpmRegistry.prototype, 'verifyAttestations')
+      .mockResolvedValue({ _attestations: {} })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  async function createAudit(transportImplementation = responseFor) {
+    const config = await RegistryConfig.load({ argv: [], env, cwd: project })
+    const calls = []
+    const fetcher = {
+      json: jest.fn(async (requestPath, options) => {
+        const registry = config.registryFor(options.spec)
+        const url = new URL(requestPath, registry).toString()
+        calls.push({ url, requestPath, options })
+        return transportImplementation(requestPath, options)
+      })
+    }
+    const registryClient = new RegistryClient(config, { fetcher })
+    const marshall = new Marshall({
+      pkgs: [['unscoped-tool@1.0.0', '@company/tool@1.0.0']],
+      registryClient
+    })
+    return { calls, config, fetcher, marshall, registryClient }
+  }
+
+  test('routes metadata, keys, and attestations without public-registry fallback', async () => {
+    const { calls, marshall } = await createAudit()
+
+    const results = await marshall.process()
+
+    expect(results).toBeDefined()
+    expect(calls.every(({ url }) => !url.includes('registry.npmjs.org'))).toBe(true)
+    expect(calls.every(({ url }) => !url.includes('api.npmjs.org'))).toBe(true)
+    expect(
+      calls.every(
+        ({ options }) =>
+          options['//artifactory.example.test/artifactory/api/npm/:_authToken'] ===
+          'integration-secret'
+      )
+    ).toBe(true)
+    expect(
+      calls.some(({ url }) =>
+        url.startsWith(
+          'https://artifactory.example.test/artifactory/api/npm/company/@company%2ftool'
+        )
+      )
+    ).toBe(true)
+    expect(
+      calls.some(({ url }) =>
+        url.startsWith(
+          'https://artifactory.example.test/artifactory/api/npm/company/-/npm/v1/attestations/'
+        )
+      )
+    ).toBe(true)
+    expect(JSON.stringify(results)).not.toContain('integration-secret')
+  })
+
+  test('reports one cached signing-key capability skip and no download requests', async () => {
+    const missing = Object.assign(new Error('not found'), { statusCode: 404 })
+    const { calls, marshall } = await createAudit((requestPath, options) => {
+      if (requestPath === '-/npm/v1/keys') {
+        throw missing
+      }
+      return responseFor(requestPath, options)
+    })
+
+    const results = await marshall.process()
+    const auditResults = Object.values(results)[0]
+    const signingKeyCalls = calls.filter(
+      ({ requestPath }) => requestPath === '-/npm/v1/keys'
+    )
+
+    expect(signingKeyCalls).toHaveLength(2)
+    expect(auditResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          signatures: expect.objectContaining({
+            errors: [],
+            warnings: [],
+            notEvaluated: expect.arrayContaining([
+              expect.objectContaining({
+                message: 'configured registry does not expose signing keys'
+              })
+            ])
+          })
+        }),
+        expect.objectContaining({
+          downloads: expect.objectContaining({
+            errors: [],
+            warnings: [],
+            notEvaluated: expect.arrayContaining([
+              expect.objectContaining({
+                message: 'download counts are available only for the public npm registry'
+              })
+            ])
+          })
+        })
+      ])
+    )
+    expect(calls.some(({ url }) => url.includes('api.npmjs.org'))).toBe(false)
+  })
+
+  test.each([
+    ['metadata authentication failure', '@company%2ftool', 401, 'EREGISTRYAUTH'],
+    ['signing-key server failure', '-/npm/v1/keys', 500, 'EREGISTRYHTTP']
+  ])('rejects the audit on %s', async (_name, failingPath, statusCode, code) => {
+    const failure = Object.assign(new Error('transport detail'), { statusCode })
+    const { marshall } = await createAudit((requestPath, options) => {
+      if (requestPath === failingPath) {
+        throw failure
+      }
+      return responseFor(requestPath, options)
+    })
+
+    await expect(marshall.process()).rejects.toMatchObject({
+      name: 'RegistryError',
+      code,
+      message: expect.not.stringContaining('integration-secret')
+    })
+  })
+
+  test.each([
+    ['malformed signing keys', '-/npm/v1/keys', { invalid: true }],
+    [
+      'malformed attestations',
+      '-/npm/v1/attestations/',
+      { invalid: true }
+    ]
+  ])('rejects the audit on %s', async (_name, failingPath, response) => {
+    const { marshall } = await createAudit((requestPath, options) => {
+      if (requestPath.startsWith(failingPath)) {
+        return response
+      }
+      return responseFor(requestPath, options)
+    })
+
+    await expect(marshall.process()).rejects.toMatchObject({
+      name: 'RegistryError',
+      code: 'EREGISTRYPROTOCOL'
+    })
+  })
+})

--- a/__tests__/exitCode.test.js
+++ b/__tests__/exitCode.test.js
@@ -32,6 +32,14 @@ jest.mock('../lib/helpers/sourcePackages', () => ({
   getProjectPackages: jest.fn().mockResolvedValue(['express'])
 }))
 
+jest.mock('../lib/helpers/registryConfig', () => ({
+  load: jest.fn().mockResolvedValue({ requestOptions: {} })
+}))
+
+jest.mock('../lib/helpers/registryClient', () =>
+  jest.fn().mockImplementation(() => ({ registryFor: jest.fn() }))
+)
+
 jest.mock('../lib/helpers/promiseThrottler', () => ({
   promiseThrottleHelper: jest.fn()
 }))
@@ -101,6 +109,30 @@ describe('npq-hero exit code propagation', () => {
     await flushPromises()
 
     expect(process.exitCode).toBe(1)
+  })
+
+  test('loads and injects registry configuration', async () => {
+    const { CliParser } = require('../lib/cli')
+    const RegistryConfig = require('../lib/helpers/registryConfig')
+    const RegistryClient = require('../lib/helpers/registryClient')
+    const Marshall = require('../lib/marshall')
+    CliParser.parseArgsMinimal.mockReturnValue({
+      packages: ['@company/tool'],
+      registryConfigArgs: [
+        '--registry=https://artifactory.example.test/api/npm/npm/'
+      ]
+    })
+
+    require('../bin/npq-hero.js')
+    await flushPromises()
+
+    expect(RegistryConfig.load).toHaveBeenCalledWith({
+      argv: ['--registry=https://artifactory.example.test/api/npm/npm/']
+    })
+    expect(RegistryClient).toHaveBeenCalled()
+    expect(Marshall).toHaveBeenCalledWith(
+      expect.objectContaining({ registryClient: expect.any(Object) })
+    )
   })
 })
 

--- a/__tests__/exitCode.test.js
+++ b/__tests__/exitCode.test.js
@@ -134,6 +134,34 @@ describe('npq-hero exit code propagation', () => {
       expect.objectContaining({ registryClient: expect.any(Object) })
     )
   })
+
+  test('prints skipped checks and installs without prompting', async () => {
+    const { CliParser } = require('../lib/cli')
+    const { reportResults } = require('../lib/helpers/reportResults')
+    const cliPrompt = require('../lib/helpers/cliPrompt.js')
+    const pkgMgr = require('../lib/packageManager')
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+    CliParser.parseArgsMinimal.mockReturnValue({ packages: ['@company/tool'] })
+    reportResults.mockReturnValue({
+      countErrors: 0,
+      countWarnings: 0,
+      countNotEvaluated: 2,
+      resultsForPlainTextPrint: 'skipped-plain',
+      summaryForPlainTextPrint: 'summary-plain',
+      useRichFormatting: false
+    })
+
+    require('../bin/npq-hero.js')
+    await flushPromises()
+
+    expect(consoleLog).toHaveBeenCalledWith('Package checks not evaluated:')
+    expect(consoleLog).toHaveBeenCalledWith('skipped-plain')
+    expect(cliPrompt.prompt).not.toHaveBeenCalled()
+    expect(cliPrompt.autoContinue).not.toHaveBeenCalled()
+    expect(pkgMgr.process).toHaveBeenCalled()
+
+    consoleLog.mockRestore()
+  })
 })
 
 describe('npq exit code propagation', () => {
@@ -283,5 +311,41 @@ describe('npq exit code propagation', () => {
     await flushPromises()
 
     expect(CliParser.exit).toHaveBeenCalledWith(expect.objectContaining({ errorCode: 1 }))
+  })
+
+  test('audit-only prints skipped checks and exits successfully', async () => {
+    jest.resetModules()
+    jest.clearAllMocks()
+    mockProcessExit.mockClear()
+    process.exitCode = undefined
+    const consoleLog = jest.spyOn(console, 'log').mockImplementation(() => {})
+
+    const { CliParser } = require('../lib/cli')
+    CliParser.parseArgsFull.mockImplementation(() => ({
+      packages: ['@company/tool'],
+      packageManager: 'npm',
+      dryRun: false,
+      plain: true,
+      disableAutoContinue: false,
+      installSubcommandExplicit: false
+    }))
+
+    const { reportResults } = require('../lib/helpers/reportResults')
+    reportResults.mockReturnValue({
+      countErrors: 0,
+      countWarnings: 0,
+      countNotEvaluated: 2,
+      resultsForPlainTextPrint: 'skipped-plain',
+      summaryForPlainTextPrint: 'summary-plain',
+      useRichFormatting: false
+    })
+
+    require('../bin/npq.js')
+    await flushPromises()
+
+    expect(consoleLog).toHaveBeenCalledWith('Package checks not evaluated:')
+    expect(CliParser.exit).toHaveBeenCalledWith(expect.objectContaining({ errorCode: 0 }))
+
+    consoleLog.mockRestore()
   })
 })

--- a/__tests__/marshall.test.js
+++ b/__tests__/marshall.test.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const Marshall = require('../lib/marshall')
+
+test('accepts null options as an empty audit', async () => {
+  const marshall = new Marshall(null)
+
+  await expect(marshall.process()).resolves.toBeUndefined()
+})
+
+test('inherits the registry client from an injected package repository helper', () => {
+  const registryClient = { registryFor: jest.fn() }
+  const packageRepoUtils = { registryClient }
+
+  const marshall = new Marshall({
+    pkgs: ['@company/tool'],
+    packageRepoUtils
+  })
+
+  expect(marshall.registryClient).toBe(registryClient)
+  expect(marshall.packageRepoUtils).toBe(packageRepoUtils)
+})

--- a/__tests__/marshalls.base.test.js
+++ b/__tests__/marshalls.base.test.js
@@ -113,3 +113,46 @@ test('base marshall implemented isEnabled', async () => {
   const result = await testMarshall.run(ctx, task)
   expect(result).toStrictEqual([undefined])
 })
+
+test('checkPackage records NotEvaluated separately from findings', async () => {
+  const NotEvaluated = require('../lib/helpers/notEvaluated')
+  const marshall = new BaseMarshall({ packageRepoUtils: null })
+  marshall.name = 'optional'
+  marshall.validate = jest.fn().mockRejectedValue(
+    new NotEvaluated('configured registry does not expose signing keys', {
+      capability: 'signing-keys'
+    })
+  )
+  const ctx = { pkgs: [], marshalls: {} }
+  marshall.init(ctx)
+
+  await marshall.checkPackage({ packageString: 'private-package@1.0.0' }, ctx)
+
+  expect(ctx.marshalls.optional.errors).toEqual([])
+  expect(ctx.marshalls.optional.warnings).toEqual([])
+  expect(ctx.marshalls.optional.notEvaluated).toEqual([
+    {
+      pkg: 'private-package@1.0.0',
+      message: 'configured registry does not expose signing keys'
+    }
+  ])
+})
+
+test('checkPackage rethrows fatal RegistryError', async () => {
+  const { RegistryError } = require('../lib/helpers/registryErrors')
+  const marshall = new BaseMarshall({ packageRepoUtils: null })
+  marshall.name = 'optional'
+  marshall.validate = jest.fn().mockRejectedValue(
+    new RegistryError('Registry authentication failed', {
+      registry: 'https://user:secret@artifactory.example.test/api/npm/npm/',
+      code: 'EREGISTRYAUTH',
+      statusCode: 401
+    })
+  )
+  const ctx = { pkgs: [], marshalls: {} }
+  marshall.init(ctx)
+
+  await expect(
+    marshall.checkPackage({ packageString: 'private-package@1.0.0' }, ctx)
+  ).rejects.toMatchObject({ code: 'EREGISTRYAUTH', statusCode: 401 })
+})

--- a/__tests__/marshalls.downloads.test.js
+++ b/__tests__/marshalls.downloads.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const Marshall = require('../lib/marshalls/downloads.marshall')
+const NotEvaluated = require('../lib/helpers/notEvaluated')
 const Warning = require('../lib/helpers/warning')
 
 describe('Downloads Marshall', () => {
@@ -14,5 +15,32 @@ describe('Downloads Marshall', () => {
     const p = marshall.validate(pkg)
     await expect(p).rejects.toThrow(Warning)
     await expect(p).rejects.toThrow('8,354 downloads last month')
+  })
+
+  it('records custom-registry download checks as not evaluated', async () => {
+    const mockPackageRepoUtils = {
+      getDownloadInfo: jest.fn().mockRejectedValue(
+        new NotEvaluated('download counts are unavailable for custom registries', {
+          capability: 'downloads'
+        })
+      )
+    }
+    const marshall = new Marshall({ packageRepoUtils: mockPackageRepoUtils })
+    const ctx = {
+      pkgs: [{ packageName: '@company/tool', packageString: '@company/tool@1.0.0' }],
+      marshalls: {}
+    }
+    marshall.init(ctx)
+
+    await marshall.run(ctx)
+
+    expect(ctx.marshalls.downloads.errors).toEqual([])
+    expect(ctx.marshalls.downloads.warnings).toEqual([])
+    expect(ctx.marshalls.downloads.notEvaluated).toEqual([
+      {
+        pkg: '@company/tool@1.0.0',
+        message: 'download counts are unavailable for custom registries'
+      }
+    ])
   })
 })

--- a/__tests__/marshalls.provenance.test.js
+++ b/__tests__/marshalls.provenance.test.js
@@ -1000,6 +1000,52 @@ describe('Provenance test suites', () => {
     expect(verify).toHaveBeenCalledWith(manifest, keys, attestations)
   })
 
+  test('keeps registry routing bound to the requested package name', async () => {
+    const manifest = {
+      name: 'response-name',
+      version: '1.0.0',
+      dist: {
+        attestations: {
+          url: 'https://registry.npmjs.org/-/npm/v1/attestations/response-name@1.0.0'
+        }
+      }
+    }
+    const packument = {
+      name: 'response-name',
+      versions: { '1.0.0': manifest }
+    }
+    const registryClient = {
+      getManifest: jest.fn().mockResolvedValue(manifest),
+      getRegistryKeys: jest.fn().mockResolvedValue([{ keyid: 'key-1' }]),
+      getAttestations: jest.fn().mockResolvedValue([{ bundle: {} }])
+    }
+    jest
+      .spyOn(NpmRegistry.prototype, 'verifyAttestations')
+      .mockResolvedValue({ _attestations: {} })
+    const marshall = new ProvenanceMarshall({
+      packageRepoUtils: {
+        getPackageInfo: jest.fn().mockResolvedValue(packument),
+        parsePackageVersion: jest.fn()
+      },
+      registryClient
+    })
+
+    await marshall.validate({
+      packageName: '@company/tool',
+      packageVersion: '1.0.0'
+    })
+
+    expect(registryClient.getManifest).toHaveBeenCalledWith(
+      '@company/tool@1.0.0',
+      packument
+    )
+    expect(registryClient.getRegistryKeys).toHaveBeenCalledWith('@company/tool')
+    expect(registryClient.getAttestations).toHaveBeenCalledWith(
+      '@company/tool',
+      manifest
+    )
+  })
+
   test.each([
     new NotEvaluated('configured registry does not expose attestations', {
       capability: 'attestations'

--- a/__tests__/marshalls.provenance.test.js
+++ b/__tests__/marshalls.provenance.test.js
@@ -4,14 +4,46 @@
 global.fetch = jest.fn()
 
 const NpmRegistry = require('../lib/helpers/npmRegistry')
-const ProvenanceMarshall = require('../lib/marshalls/provenance.marshall')
+const ProvenanceMarshallBase = require('../lib/marshalls/provenance.marshall')
 const Warning = require('../lib/helpers/warning')
+const NotEvaluated = require('../lib/helpers/notEvaluated')
+const { RegistryError } = require('../lib/helpers/registryErrors')
+
+const defaultRegistryClient = {
+  getManifest: jest.fn(async (packageSpec, packument) => {
+    const version = packageSpec.slice(packageSpec.lastIndexOf('@') + 1)
+    if (!packument.versions || !packument.versions[version]) {
+      throw new Error(`Version ${version} not found`)
+    }
+    return packument.versions[version]
+  }),
+  getRegistryKeys: jest.fn().mockResolvedValue([]),
+  getAttestations: jest.fn().mockResolvedValue([])
+}
+
+class ProvenanceMarshall extends ProvenanceMarshallBase {
+  constructor(options) {
+    super({
+      ...options,
+      registryClient: options.registryClient || defaultRegistryClient
+    })
+  }
+}
 
 describe('Provenance test suites', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.resetAllMocks()
     jest.restoreAllMocks()
+    defaultRegistryClient.getManifest.mockImplementation(async (packageSpec, packument) => {
+      const version = packageSpec.slice(packageSpec.lastIndexOf('@') + 1)
+      if (!packument.versions || !packument.versions[version]) {
+        throw new Error(`Version ${version} not found`)
+      }
+      return packument.versions[version]
+    })
+    defaultRegistryClient.getRegistryKeys.mockResolvedValue([])
+    defaultRegistryClient.getAttestations.mockResolvedValue([])
   })
 
   test('returns _attestations when verifyAttestations resolves successfully', async () => {
@@ -167,14 +199,7 @@ describe('Provenance test suites', () => {
       expect(error.message).not.toContain('Version 1.0.0 not found')
     }
 
-    // Assert that the fetch method is called with the correct URL for keys
-    expect(global.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/-/npm/v1/keys')
-
-    // Assert that fetch is called for the package manifest
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://registry.npmjs.org/packageName',
-      expect.any(Object)
-    )
+    expect(defaultRegistryClient.getManifest).toHaveBeenCalled()
   })
 
   test('should throw an error if attestation verification fails and manifest() throws an error', async () => {
@@ -284,8 +309,7 @@ describe('Provenance test suites', () => {
     expect(err).toBeInstanceOf(Warning)
     expect(err.message).toContain('Unable to verify provenance')
 
-    // Assert that the fetch method is called with the correct URL for keys
-    expect(global.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/-/npm/v1/keys')
+    expect(defaultRegistryClient.getManifest).toHaveBeenCalled()
   })
 
   test('throws Error (provenance regression) when an older semver had dist.attestations but the target does not', async () => {
@@ -483,9 +507,7 @@ describe('Provenance test suites', () => {
     expect(result).toEqual([])
   })
 
-  test('rethrows Warning when registry keys fetch fails', async () => {
-    global.fetch = jest.fn().mockRejectedValue(new Error('network down'))
-
+  test('does not fetch registry keys when the manifest has no attestations', async () => {
     const testMarshall = new ProvenanceMarshall({
       packageRepoUtils: {
         getPackageInfo: () =>
@@ -509,7 +531,10 @@ describe('Provenance test suites', () => {
       .catch((e) => e)
 
     expect(err).toBeInstanceOf(Warning)
-    expect(err.message).toContain('Error fetching registry keys')
+    expect(err.message).toContain(
+      'Unable to verify provenance: the package was published without any attestations'
+    )
+    expect(defaultRegistryClient.getRegistryKeys).not.toHaveBeenCalled()
   })
 
   test('throws Error when version cannot be resolved', async () => {
@@ -922,5 +947,98 @@ describe('Provenance test suites', () => {
 
     expect(err).toBeInstanceOf(Warning)
     expect(err.message).toBe('Unable to verify provenance')
+  })
+
+  test('uses the injected registry client for provenance inputs', async () => {
+    const packument = {
+      name: 'packageName',
+      versions: {
+        '1.0.0': {
+          name: 'packageName',
+          version: '1.0.0',
+          dist: {
+            attestations: {
+              url: 'https://registry.npmjs.org/-/npm/v1/attestations/packageName@1.0.0'
+            }
+          }
+        }
+      }
+    }
+    const manifest = packument.versions['1.0.0']
+    const attestations = [{ bundle: {} }]
+    const keys = [{ keyid: 'key-1' }]
+    const registryClient = {
+      getManifest: jest.fn().mockResolvedValue(manifest),
+      getRegistryKeys: jest.fn().mockResolvedValue(keys),
+      getAttestations: jest.fn().mockResolvedValue(attestations)
+    }
+    const verify = jest
+      .spyOn(NpmRegistry.prototype, 'verifyAttestations')
+      .mockResolvedValue({ _attestations: {} })
+    const marshall = new ProvenanceMarshall({
+      packageRepoUtils: {
+        getPackageInfo: jest.fn().mockResolvedValue(packument),
+        parsePackageVersion: jest.fn()
+      },
+      registryClient
+    })
+
+    await marshall.validate({
+      packageName: 'packageName',
+      packageVersion: '1.0.0'
+    })
+
+    expect(registryClient.getManifest).toHaveBeenCalledWith(
+      'packageName@1.0.0',
+      packument
+    )
+    expect(registryClient.getRegistryKeys).toHaveBeenCalledWith('packageName')
+    expect(registryClient.getAttestations).toHaveBeenCalledWith(
+      'packageName',
+      manifest
+    )
+    expect(verify).toHaveBeenCalledWith(manifest, keys, attestations)
+  })
+
+  test.each([
+    new NotEvaluated('configured registry does not expose attestations', {
+      capability: 'attestations'
+    }),
+    new RegistryError('Registry authentication failed', {
+      registry: 'https://artifactory.example.test/npm/',
+      code: 'EREGISTRYAUTH'
+    })
+  ])('rethrows typed provenance registry failures', async (failure) => {
+    const manifest = {
+      name: 'packageName',
+      version: '1.0.0',
+      dist: {
+        attestations: {
+          url: 'https://registry.npmjs.org/-/npm/v1/attestations/packageName@1.0.0'
+        }
+      }
+    }
+    const packument = {
+      name: 'packageName',
+      versions: { '1.0.0': manifest }
+    }
+    const marshall = new ProvenanceMarshall({
+      packageRepoUtils: {
+        getPackageInfo: jest.fn().mockResolvedValue(packument),
+        parsePackageVersion: jest.fn()
+      },
+      registryClient: {
+        getManifest: jest.fn().mockResolvedValue(manifest),
+        getRegistryKeys: jest.fn().mockResolvedValue([]),
+        getAttestations: jest.fn().mockRejectedValue(failure)
+      }
+    })
+
+    await expect(
+      marshall.validate({
+        packageName: 'packageName',
+        packageVersion: '1.0.0'
+      })
+    ).rejects.toBe(failure)
   })
 })

--- a/__tests__/marshalls.signatures.test.js
+++ b/__tests__/marshalls.signatures.test.js
@@ -3,12 +3,43 @@
 // Mock fetch for testing
 global.fetch = jest.fn()
 
-const SignaturesMarshall = require('../lib/marshalls/signatures.marshall')
+const SignaturesMarshallBase = require('../lib/marshalls/signatures.marshall')
+const NpmRegistry = require('../lib/helpers/npmRegistry')
+const NotEvaluated = require('../lib/helpers/notEvaluated')
+const { RegistryError } = require('../lib/helpers/registryErrors')
+
+const defaultRegistryClient = {
+  getManifest: jest.fn(async (packageSpec, packument) => {
+    const version = packageSpec.slice(packageSpec.lastIndexOf('@') + 1)
+    if (!packument.versions || !packument.versions[version]) {
+      throw new Error(`Version ${version} not found`)
+    }
+    return packument.versions[version]
+  }),
+  getRegistryKeys: jest.fn().mockResolvedValue([])
+}
+
+class SignaturesMarshall extends SignaturesMarshallBase {
+  constructor(options) {
+    super({
+      ...options,
+      registryClient: options.registryClient || defaultRegistryClient
+    })
+  }
+}
 
 describe('Signature test suites', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.resetAllMocks()
+    defaultRegistryClient.getManifest.mockImplementation(async (packageSpec, packument) => {
+      const version = packageSpec.slice(packageSpec.lastIndexOf('@') + 1)
+      if (!packument.versions || !packument.versions[version]) {
+        throw new Error(`Version ${version} not found`)
+      }
+      return packument.versions[version]
+    })
+    defaultRegistryClient.getRegistryKeys.mockResolvedValue([])
   })
 
   test('has the right title', async () => {
@@ -122,17 +153,13 @@ describe('Signature test suites', () => {
     // Assert that getPackageInfo is called for version resolution
     expect(testMarshall.packageRepoUtils.getPackageInfo).toHaveBeenCalledWith('packageName')
 
-    // Assert that the fetch method is called with the correct URL for keys
-    expect(global.fetch).toHaveBeenCalledWith('https://registry.npmjs.org/-/npm/v1/keys')
-
-    // Assert that fetch is called for the package manifest
-    expect(global.fetch).toHaveBeenCalledWith(
-      'https://registry.npmjs.org/packageName',
-      expect.any(Object)
+    expect(defaultRegistryClient.getManifest).toHaveBeenCalledWith(
+      'packageName@1.0.0',
+      mockPackageData
     )
   })
 
-  test('should throw an error if keys dont match and manifest() throws an error', async () => {
+  test('wraps package signature verification failures as warnings', async () => {
     // Mock the response from fetch for keys
     const mockKeysResponse = {
       ok: true,
@@ -172,5 +199,83 @@ describe('Signature test suites', () => {
     await expect(testMarshall.validate(pkg)).rejects.toThrow(
       'Unable to verify package signature on registry'
     )
+  })
+
+  test('uses the injected registry client for manifests and signing keys', async () => {
+    const packument = {
+      'dist-tags': { latest: '1.0.0' },
+      versions: {
+        '1.0.0': {
+          name: 'packageName',
+          version: '1.0.0',
+          dist: { signatures: [{}] }
+        }
+      }
+    }
+    const manifest = packument.versions['1.0.0']
+    const registryClient = {
+      getManifest: jest.fn().mockResolvedValue(manifest),
+      getRegistryKeys: jest.fn().mockResolvedValue([{ keyid: 'key-1' }])
+    }
+    const verify = jest
+      .spyOn(NpmRegistry.prototype, 'verifySignatures')
+      .mockResolvedValue({ _signatures: [{}] })
+    const marshall = new SignaturesMarshall({
+      packageRepoUtils: {
+        getPackageInfo: jest.fn().mockResolvedValue(packument),
+        parsePackageVersion: jest.fn()
+      },
+      registryClient
+    })
+
+    await marshall.validate({
+      packageName: 'packageName',
+      packageVersion: '1.0.0'
+    })
+
+    expect(registryClient.getManifest).toHaveBeenCalledWith(
+      'packageName@1.0.0',
+      packument
+    )
+    expect(registryClient.getRegistryKeys).toHaveBeenCalledWith('packageName')
+    expect(verify).toHaveBeenCalledWith(manifest, [{ keyid: 'key-1' }])
+    verify.mockRestore()
+  })
+
+  test.each([
+    new NotEvaluated('configured registry does not expose signing keys', {
+      capability: 'signing-keys'
+    }),
+    new RegistryError('Registry authentication failed', {
+      registry: 'https://artifactory.example.test/npm/',
+      code: 'EREGISTRYAUTH'
+    })
+  ])('rethrows typed registry failures without wrapping', async (failure) => {
+    const packument = {
+      versions: {
+        '1.0.0': {
+          name: 'packageName',
+          version: '1.0.0',
+          dist: { signatures: [{}] }
+        }
+      }
+    }
+    const marshall = new SignaturesMarshall({
+      packageRepoUtils: {
+        getPackageInfo: jest.fn().mockResolvedValue(packument),
+        parsePackageVersion: jest.fn()
+      },
+      registryClient: {
+        getManifest: jest.fn().mockResolvedValue(packument.versions['1.0.0']),
+        getRegistryKeys: jest.fn().mockRejectedValue(failure)
+      }
+    })
+
+    await expect(
+      marshall.validate({
+        packageName: 'packageName',
+        packageVersion: '1.0.0'
+      })
+    ).rejects.toBe(failure)
   })
 })

--- a/__tests__/marshalls.tasks.test.js
+++ b/__tests__/marshalls.tasks.test.js
@@ -25,6 +25,7 @@ test('running marshall tasks succeeds', async () => {
     status: null,
     errors: [],
     warnings: [],
+    notEvaluated: [],
     data: { express: 'mock data check', semver: 'mock data check' },
     marshall: 'test.marshall',
     categoryId: 'PackageHealth'
@@ -116,6 +117,7 @@ test('running marshall tasks filters out not found packages when multiple packag
     status: null,
     errors: [{ pkg: 'nonexistent-package', message: 'Package not found' }],
     warnings: [],
+    notEvaluated: [],
     data: {},
     marshall: 'not_found',
     categoryId: 'PackageHealth'
@@ -125,8 +127,29 @@ test('running marshall tasks filters out not found packages when multiple packag
     status: null,
     errors: [],
     warnings: [],
+    notEvaluated: [],
     data: { express: 'mock data check', semver: 'mock data check' },
     marshall: 'test.marshall',
     categoryId: 'PackageHealth'
+  })
+})
+
+test('running marshall tasks propagates fatal registry errors', async () => {
+  marshalls.collectMarshalls = jest.fn().mockResolvedValue([
+    path.join(process.cwd(), '__tests__/__fixtures__/fatalRegistry.marshall.js')
+  ])
+  const config = {
+    pkgs: [
+      {
+        packageName: 'private-package',
+        packageString: 'private-package@1.0.0'
+      }
+    ],
+    packageRepoUtils: new PackageRepoUtilsMock()
+  }
+
+  await expect(marshalls.tasks(config)).rejects.toMatchObject({
+    name: 'RegistryError',
+    code: 'EREGISTRYNETWORK'
   })
 })

--- a/__tests__/npmRegistry.test.js
+++ b/__tests__/npmRegistry.test.js
@@ -32,232 +32,12 @@ jest.mock('ssri', () => ({
   })
 }))
 
-// Mock fetch globally
-global.fetch = jest.fn()
-
 describe('NpmRegistry', () => {
   let npmRegistry
 
   beforeEach(() => {
     jest.clearAllMocks()
     npmRegistry = new NpmRegistry()
-  })
-
-  describe('Constructor', () => {
-    test('should create instance with default registry', () => {
-      const registry = new NpmRegistry()
-      expect(registry.registry).toBe('https://registry.npmjs.org')
-      expect(registry.opts).toEqual({})
-    })
-
-    test('should create instance with custom registry', () => {
-      const customRegistry = 'https://custom.registry.com'
-      const registry = new NpmRegistry({ registry: customRegistry })
-      expect(registry.registry).toBe(customRegistry)
-      expect(registry.opts).toEqual({ registry: customRegistry })
-    })
-
-    test('should store additional options', () => {
-      const opts = { registry: 'https://custom.com', timeout: 5000 }
-      const registry = new NpmRegistry(opts)
-      expect(registry.opts).toEqual(opts)
-    })
-  })
-
-  describe('getManifest', () => {
-    test('should fetch package manifest successfully', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '1.0.0' },
-        versions: {
-          '1.0.0': {
-            name: 'express',
-            version: '1.0.0',
-            dist: {
-              tarball: 'https://registry.npmjs.org/express/-/express-1.0.0.tgz',
-              integrity: 'sha512-example'
-            }
-          }
-        },
-        time: {
-          '1.0.0': '2023-01-01T00:00:00.000Z'
-        }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      const manifest = await npmRegistry.getManifest('express@1.0.0')
-
-      expect(fetch).toHaveBeenCalledWith('https://registry.npmjs.org/express', {
-        headers: {
-          accept: 'application/json',
-          'user-agent': 'npq-npm-registry-client'
-        }
-      })
-      expect(manifest.name).toBe('express')
-      expect(manifest.version).toBe('1.0.0')
-      expect(manifest._time).toBe('2023-01-01T00:00:00.000Z')
-    })
-
-    test('should handle latest tag when no version specified', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '2.0.0' },
-        versions: {
-          '2.0.0': {
-            name: 'express',
-            version: '2.0.0'
-          }
-        }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      const manifest = await npmRegistry.getManifest('express')
-      expect(manifest.version).toBe('2.0.0')
-    })
-
-    test('should handle explicit latest tag', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '3.0.0' },
-        versions: {
-          '3.0.0': {
-            name: 'express',
-            version: '3.0.0'
-          }
-        }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      const manifest = await npmRegistry.getManifest('express@latest')
-      expect(manifest.version).toBe('3.0.0')
-    })
-
-    test('should pass custom headers', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '1.0.0' },
-        versions: {
-          '1.0.0': { name: 'express', version: '1.0.0' }
-        }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      await npmRegistry.getManifest('express', {
-        headers: { authorization: 'Bearer token' }
-      })
-
-      expect(fetch).toHaveBeenCalledWith('https://registry.npmjs.org/express', {
-        headers: {
-          accept: 'application/json',
-          'user-agent': 'npq-npm-registry-client',
-          authorization: 'Bearer token'
-        }
-      })
-    })
-
-    test('should handle fetch failure', async () => {
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found'
-      })
-
-      await expect(npmRegistry.getManifest('nonexistent')).rejects.toThrow(
-        'Failed to fetch package manifest: 404 Not Found'
-      )
-    })
-
-    test('should handle missing version', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '1.0.0' },
-        versions: {
-          '1.0.0': { name: 'express', version: '1.0.0' }
-        }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      await expect(npmRegistry.getManifest('express@2.0.0')).rejects.toThrow(
-        'Version 2.0.0 not found for package express'
-      )
-    })
-
-    test('should handle missing versions object', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '1.0.0' }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      await expect(npmRegistry.getManifest('express@1.0.0')).rejects.toThrow(
-        'Version 1.0.0 not found for package express'
-      )
-    })
-
-    test('should handle missing time information gracefully', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '1.0.0' },
-        versions: {
-          '1.0.0': {
-            name: 'express',
-            version: '1.0.0'
-          }
-        }
-        // No time field
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      const manifest = await npmRegistry.getManifest('express@1.0.0')
-      expect(manifest._time).toBeUndefined()
-    })
-
-    test('should handle scoped packages', async () => {
-      const mockPackument = {
-        'dist-tags': { latest: '1.0.0' },
-        versions: {
-          '1.0.0': {
-            name: '@scope/package',
-            version: '1.0.0'
-          }
-        }
-      }
-
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockPackument)
-      })
-
-      await npmRegistry.getManifest('@scope/package@1.0.0')
-
-      expect(fetch).toHaveBeenCalledWith('https://registry.npmjs.org/@scope%2fpackage', {
-        headers: {
-          accept: 'application/json',
-          'user-agent': 'npq-npm-registry-client'
-        }
-      })
-    })
   })
 
   describe('verifySignatures', () => {
@@ -469,7 +249,7 @@ describe('NpmRegistry', () => {
       ).rejects.toThrow('Package has no attestations to verify')
     })
 
-    test('should fetch and verify attestations successfully', async () => {
+    test('should verify supplied attestations successfully', async () => {
       // Mock the statement payload with matching hex digest
       const correctHexDigest = require('ssri').parse(mockManifest.dist.integrity).hexDigest()
       const statement = {
@@ -509,39 +289,21 @@ describe('NpmRegistry', () => {
         ]
       }
 
-      // Mock fetch for attestations
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockAttestations)
-      })
-
       // Mock sigstore verification
       sigstore.verify.mockResolvedValue()
 
-      const result = await npmRegistry.verifyAttestations(mockManifest, mockRegistryKeys)
-
-      expect(fetch).toHaveBeenCalledWith(
-        'https://registry.npmjs.org/-/npm/v1/attestations/express@1.0.0',
-        {
-          headers: {
-            accept: 'application/json',
-            'user-agent': 'npq-npm-registry-client'
-          }
-        }
+      const result = await npmRegistry.verifyAttestations(
+        mockManifest,
+        mockRegistryKeys,
+        mockAttestations.attestations
       )
       expect(result._attestations).toEqual(mockManifest.dist.attestations)
     })
 
-    test('should handle fetch failure for attestations', async () => {
-      fetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        statusText: 'Not Found'
-      })
-
-      await expect(npmRegistry.verifyAttestations(mockManifest, mockRegistryKeys)).rejects.toThrow(
-        'Failed to fetch attestations: 404 Not Found'
-      )
+    test('should reject an invalid attestations response', async () => {
+      await expect(
+        npmRegistry.verifyAttestations(mockManifest, mockRegistryKeys, null)
+      ).rejects.toThrow('Package attestations response is invalid')
     })
 
     test('should throw error when no corresponding public key found', async () => {
@@ -564,14 +326,9 @@ describe('NpmRegistry', () => {
         ]
       }
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockAttestations)
-      })
-
-      await expect(npmRegistry.verifyAttestations(mockManifest, [])).rejects.toThrow(
-        /has attestations but no corresponding public key\(s\) can be found/
-      )
+      await expect(
+        npmRegistry.verifyAttestations(mockManifest, [], mockAttestations.attestations)
+      ).rejects.toThrow(/has attestations but no corresponding public key\(s\) can be found/)
     })
 
     test('should handle attestation verification failure', async () => {
@@ -608,17 +365,16 @@ describe('NpmRegistry', () => {
         ]
       }
 
-      fetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve(mockAttestations)
-      })
-
       // Mock sigstore verification failure
       sigstore.verify.mockRejectedValue(new Error('Verification failed'))
 
-      await expect(npmRegistry.verifyAttestations(mockManifest, mockRegistryKeys)).rejects.toThrow(
-        /failed to verify attestation: Verification failed/
-      )
+      await expect(
+        npmRegistry.verifyAttestations(
+          mockManifest,
+          mockRegistryKeys,
+          mockAttestations.attestations
+        )
+      ).rejects.toThrow(/failed to verify attestation: Verification failed/)
     })
   })
 })

--- a/__tests__/packageManager.test.js
+++ b/__tests__/packageManager.test.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('node:events')
 const packageManager = require('../lib/packageManager')
 const childProcess = require('child_process')
+const originalArgv = process.argv
 
 function createMockChild(exitCode = 0) {
   const child = new EventEmitter()
@@ -16,6 +17,15 @@ jest.mock('child_process', () => {
       return new (require('node:events').EventEmitter)()
     })
   }
+})
+
+beforeEach(() => {
+  childProcess.spawn.mockReset()
+  process.argv = ['node', 'npq']
+})
+
+afterAll(() => {
+  process.argv = originalArgv
 })
 
 test('package manager validation should fail if provided array', () => {
@@ -102,6 +112,25 @@ test('package manager spawns with pnpm when provided as parameter', async () => 
   expect(childProcess.spawn).toHaveBeenCalled()
   expect(childProcess.spawn.mock.calls.length).toBe(1)
   expect(childProcess.spawn.mock.calls[0][0]).toEqual('pnpm install lodash')
+  childProcess.spawn.mockReset()
+})
+
+test('package manager forwards custom registry options', async () => {
+  childProcess.spawn.mockImplementation(() => createMockChild(0))
+  process.argv = [
+    'node',
+    'npq',
+    'install',
+    '@company/tool',
+    '--registry=https://artifactory.example.test/api/npm/npm/'
+  ]
+
+  await packageManager.process('pnpm')
+
+  expect(childProcess.spawn).toHaveBeenCalledWith(
+    'pnpm install @company/tool --registry=https://artifactory.example.test/api/npm/npm/',
+    expect.objectContaining({ stdio: 'inherit', shell: true })
+  )
   childProcess.spawn.mockReset()
 })
 

--- a/__tests__/packageRepoUtils.test.js
+++ b/__tests__/packageRepoUtils.test.js
@@ -1,5 +1,30 @@
 'use strict'
 
+jest.mock('../lib/helpers/registryClient', () => {
+  return class RegistryClientMock {
+    static public() {
+      return new RegistryClientMock()
+    }
+
+    registryFor() {
+      return 'https://registry.npmjs.org/'
+    }
+
+    getPackageInfo(pkg) {
+      return global.fetch(`https://registry.npmjs.org/${pkg}`).then((response) =>
+        response.json()
+      )
+    }
+
+    getDownloadInfo(pkg) {
+      return global
+        .fetch(`https://api.npmjs.org/downloads/point/last-month/${pkg}`)
+        .then((response) => response.json())
+        .then(({ downloads }) => downloads)
+    }
+  }
+})
+
 const PackageRepoUtils = require('../lib/helpers/packageRepoUtils')
 
 global.fetch = jest.fn().mockImplementation(() =>
@@ -12,25 +37,44 @@ beforeEach(() => {
   fetch.mockClear()
 })
 
-test('repo utils always has a default package registry url', () => {
-  const packageRepoUtils = new PackageRepoUtils()
-  expect(packageRepoUtils.registryUrl).toBeTruthy()
+test('repo utils delegates package metadata and downloads to RegistryClient', async () => {
+  const registryClient = {
+    registryFor: jest.fn().mockReturnValue('https://registry.example.test/'),
+    getPackageInfo: jest.fn().mockResolvedValue({ name: 'test-package' }),
+    getDownloadInfo: jest.fn().mockResolvedValue(1950)
+  }
+  const packageRepoUtils = new PackageRepoUtils({ registryClient })
+
+  await expect(packageRepoUtils.getPackageInfo('test-package')).resolves.toEqual({
+    name: 'test-package'
+  })
+  await expect(packageRepoUtils.getDownloadInfo('test-package')).resolves.toBe(
+    1950
+  )
+  expect(registryClient.getPackageInfo).toHaveBeenCalledWith('test-package')
+  expect(registryClient.getDownloadInfo).toHaveBeenCalledWith('test-package')
 })
 
-test('repo utils constructor allows setting a package registry url', () => {
-  const pkgRegistryUrl = 'https://registry.yarnpkg.com'
-  const packageRepoUtils = new PackageRepoUtils({
-    registryUrl: pkgRegistryUrl
-  })
-  expect(packageRepoUtils.registryUrl).toEqual(pkgRegistryUrl)
-})
+test('repo utils isolates package metadata cache entries by registry', async () => {
+  const registryClient = {
+    registryFor: jest
+      .fn()
+      .mockReturnValueOnce('https://one.example.test/')
+      .mockReturnValueOnce('https://two.example.test/'),
+    getPackageInfo: jest
+      .fn()
+      .mockResolvedValueOnce({ source: 'one' })
+      .mockResolvedValueOnce({ source: 'two' })
+  }
+  const packageRepoUtils = new PackageRepoUtils({ registryClient })
 
-test('repo utils constructor allows setting a package registry api url', () => {
-  const pkgRegistryApiUrl = 'https://api.npmjs.org'
-  const packageRepoUtils = new PackageRepoUtils({
-    registryApiUrl: pkgRegistryApiUrl
+  await expect(packageRepoUtils.getPackageInfo('same-package')).resolves.toEqual({
+    source: 'one'
   })
-  expect(packageRepoUtils.registryApiUrl).toEqual(pkgRegistryApiUrl)
+  await expect(packageRepoUtils.getPackageInfo('same-package')).resolves.toEqual({
+    source: 'two'
+  })
+  expect(registryClient.getPackageInfo).toHaveBeenCalledTimes(2)
 })
 
 test('repo utils returns a package json object from registry', async () => {

--- a/__tests__/registryClient.test.js
+++ b/__tests__/registryClient.test.js
@@ -230,6 +230,29 @@ describe('RegistryClient', () => {
     )
   })
 
+  test('does not duplicate a registry base path advertised in an attestation URL', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({ attestations: [{ bundle: {} }] })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+    const manifest = {
+      dist: {
+        attestations: {
+          url:
+            'https://artifactory.example.test/artifactory/api/npm/company/' +
+            '-/npm/v1/attestations/tool@1.0.0'
+        }
+      }
+    }
+
+    await client.getAttestations('@company/tool', manifest)
+
+    expect(fetcher.json).toHaveBeenCalledWith(
+      '-/npm/v1/attestations/tool@1.0.0',
+      expect.objectContaining({ spec: '@company/tool' })
+    )
+  })
+
   test('rejects malformed attestation URLs and responses', async () => {
     const fetcher = { json: jest.fn().mockResolvedValue({ invalid: true }) }
     const client = new RegistryClient(createConfig(), { fetcher })

--- a/__tests__/registryClient.test.js
+++ b/__tests__/registryClient.test.js
@@ -1,0 +1,363 @@
+'use strict'
+
+const NotEvaluated = require('../lib/helpers/notEvaluated')
+const RegistryConfig = require('../lib/helpers/registryConfig')
+const RegistryClient = require('../lib/helpers/registryClient')
+const { RegistryError } = require('../lib/helpers/registryErrors')
+
+function createConfig(options = {}) {
+  return new RegistryConfig({
+    registry: 'https://registry.npmjs.org/',
+    '@company:registry':
+      'https://artifactory.example.test/artifactory/api/npm/company/',
+    ...options
+  })
+}
+
+function httpError(statusCode) {
+  return Object.assign(new Error(`HTTP ${statusCode}`), { statusCode })
+}
+
+describe('RegistryClient', () => {
+  test('provides a public default client', () => {
+    expect(RegistryClient.public().registryFor('left-pad')).toBe(
+      'https://registry.npmjs.org/'
+    )
+  })
+
+  test('routes scoped package metadata through npm-registry-fetch options', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({ name: '@company/tool', versions: {} })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await client.getPackageInfo('@company/tool')
+
+    expect(fetcher.json).toHaveBeenCalledWith(
+      '@company%2ftool',
+      expect.objectContaining({
+        spec: '@company/tool',
+        registry: 'https://registry.npmjs.org/',
+        '@company:registry':
+          'https://artifactory.example.test/artifactory/api/npm/company/'
+      })
+    )
+  })
+
+  test('returns existing not-found data for package metadata 404', async () => {
+    const fetcher = { json: jest.fn().mockRejectedValue(httpError(404)) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getPackageInfo('missing-package')).resolves.toEqual({
+      error: 'Not found'
+    })
+  })
+
+  test.each([
+    [401, 'EREGISTRYAUTH'],
+    [403, 'EREGISTRYAUTH'],
+    [500, 'EREGISTRYHTTP']
+  ])('maps HTTP %s metadata failures to %s', async (statusCode, code) => {
+    const fetcher = {
+      json: jest.fn().mockRejectedValue(httpError(statusCode))
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getPackageInfo('private-package')).rejects.toMatchObject(
+      {
+        name: 'RegistryError',
+        code,
+        statusCode
+      }
+    )
+  })
+
+  test('maps transport failures to fatal registry errors', async () => {
+    const fetcher = {
+      json: jest.fn().mockRejectedValue(new Error('getaddrinfo ENOTFOUND'))
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getPackageInfo('private-package')).rejects.toMatchObject(
+      {
+        name: 'RegistryError',
+        code: 'EREGISTRYNETWORK'
+      }
+    )
+  })
+
+  test('rejects malformed package metadata as a protocol failure', async () => {
+    const fetcher = { json: jest.fn().mockResolvedValue('not-an-object') }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getPackageInfo('private-package')).rejects.toMatchObject(
+      {
+        name: 'RegistryError',
+        code: 'EREGISTRYPROTOCOL'
+      }
+    )
+  })
+
+  test('selects exact and latest manifests from a supplied packument', async () => {
+    const client = new RegistryClient(createConfig(), {
+      fetcher: { json: jest.fn() }
+    })
+    const packument = {
+      'dist-tags': { latest: '2.0.0' },
+      time: { '2.0.0': '2026-01-01T00:00:00.000Z' },
+      versions: {
+        '1.0.0': { name: 'pkg', version: '1.0.0' },
+        '2.0.0': { name: 'pkg', version: '2.0.0' }
+      }
+    }
+
+    await expect(client.getManifest('pkg@1.0.0', packument)).resolves.toMatchObject({
+      version: '1.0.0'
+    })
+    await expect(client.getManifest('pkg@latest', packument)).resolves.toMatchObject({
+      version: '2.0.0',
+      _time: '2026-01-01T00:00:00.000Z'
+    })
+    await expect(client.getManifest('pkg@3.0.0', packument)).rejects.toThrow(
+      'Version 3.0.0 not found for package pkg'
+    )
+  })
+
+  test('fetches a packument when one is not supplied for a manifest', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({
+        versions: {
+          '1.0.0': { name: 'pkg', version: '1.0.0' }
+        }
+      })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getManifest('pkg@1.0.0')).resolves.toMatchObject({
+      version: '1.0.0'
+    })
+  })
+
+  test.each([404, 405, 501])(
+    'classifies signing-key HTTP %s as unavailable',
+    async (statusCode) => {
+      const fetcher = {
+        json: jest.fn().mockRejectedValue(httpError(statusCode))
+      }
+      const client = new RegistryClient(createConfig(), { fetcher })
+
+      await expect(client.getRegistryKeys('@company/tool')).rejects.toBeInstanceOf(
+        NotEvaluated
+      )
+    }
+  )
+
+  test('caches unavailable signing-key capability per registry', async () => {
+    const fetcher = { json: jest.fn().mockRejectedValue(httpError(404)) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getRegistryKeys('@company/one')).rejects.toBeInstanceOf(
+      NotEvaluated
+    )
+    await expect(client.getRegistryKeys('@company/two')).rejects.toBeInstanceOf(
+      NotEvaluated
+    )
+    expect(fetcher.json).toHaveBeenCalledTimes(1)
+  })
+
+  test('formats and caches registry keys', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({
+        keys: [{ keyid: 'key-1', key: 'PUBLICKEY' }]
+      })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getRegistryKeys('one')).resolves.toEqual([
+      {
+        keyid: 'key-1',
+        key: 'PUBLICKEY',
+        pemkey:
+          '-----BEGIN PUBLIC KEY-----\nPUBLICKEY\n-----END PUBLIC KEY-----'
+      }
+    ])
+    await client.getRegistryKeys('two')
+    expect(fetcher.json).toHaveBeenCalledTimes(1)
+  })
+
+  test('treats empty keys as cached unavailable capability', async () => {
+    const fetcher = { json: jest.fn().mockResolvedValue({ keys: [] }) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getRegistryKeys('one')).rejects.toBeInstanceOf(
+      NotEvaluated
+    )
+    await expect(client.getRegistryKeys('two')).rejects.toBeInstanceOf(
+      NotEvaluated
+    )
+    expect(fetcher.json).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects malformed key responses', async () => {
+    const fetcher = { json: jest.fn().mockResolvedValue({ invalid: true }) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getRegistryKeys('one')).rejects.toMatchObject({
+      name: 'RegistryError',
+      code: 'EREGISTRYPROTOCOL'
+    })
+  })
+
+  test('rebases advertised attestation paths onto the scoped registry', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({ attestations: [{ bundle: {} }] })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+    const manifest = {
+      dist: {
+        attestations: {
+          url: 'https://registry.npmjs.org/-/npm/v1/attestations/tool@1.0.0'
+        }
+      }
+    }
+
+    await expect(
+      client.getAttestations('@company/tool', manifest)
+    ).resolves.toEqual([{ bundle: {} }])
+    expect(fetcher.json).toHaveBeenCalledWith(
+      '-/npm/v1/attestations/tool@1.0.0',
+      expect.objectContaining({ spec: '@company/tool' })
+    )
+  })
+
+  test('rejects malformed attestation URLs and responses', async () => {
+    const fetcher = { json: jest.fn().mockResolvedValue({ invalid: true }) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(
+      client.getAttestations('@company/tool', {
+        dist: { attestations: { url: 'not a url' } }
+      })
+    ).rejects.toMatchObject({ code: 'EREGISTRYPROTOCOL' })
+    await expect(
+      client.getAttestations('@company/tool', {
+        dist: {
+          attestations: {
+            url: 'https://registry.npmjs.org/-/npm/v1/attestations/tool@1.0.0'
+          }
+        }
+      })
+    ).rejects.toMatchObject({ code: 'EREGISTRYPROTOCOL' })
+  })
+
+  test('caches unavailable attestation capability per registry', async () => {
+    const fetcher = { json: jest.fn().mockRejectedValue(httpError(404)) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+    const manifest = {
+      dist: {
+        attestations: {
+          url: 'https://registry.npmjs.org/-/npm/v1/attestations/tool@1.0.0'
+        }
+      }
+    }
+
+    await expect(
+      client.getAttestations('@company/one', manifest)
+    ).rejects.toBeInstanceOf(NotEvaluated)
+    await expect(
+      client.getAttestations('@company/two', manifest)
+    ).rejects.toBeInstanceOf(NotEvaluated)
+    expect(fetcher.json).toHaveBeenCalledTimes(1)
+  })
+
+  test('treats empty attestations as unavailable', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({ attestations: [] })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+    const manifest = {
+      dist: {
+        attestations: {
+          url: 'https://registry.npmjs.org/-/npm/v1/attestations/tool@1.0.0'
+        }
+      }
+    }
+
+    await expect(
+      client.getAttestations('@company/tool', manifest)
+    ).rejects.toBeInstanceOf(NotEvaluated)
+  })
+
+  test('does not query public downloads for custom-registry packages', async () => {
+    const fetcher = { json: jest.fn() }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getDownloadInfo('@company/tool')).rejects.toMatchObject({
+      name: 'NotEvaluated',
+      capability: 'download-counts'
+    })
+    expect(fetcher.json).not.toHaveBeenCalled()
+  })
+
+  test('queries the public npm downloads service only for public packages', async () => {
+    const fetcher = {
+      json: jest.fn().mockResolvedValue({ downloads: 1234 })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getDownloadInfo('left-pad')).resolves.toBe(1234)
+    expect(fetcher.json).toHaveBeenCalledWith(
+      'https://api.npmjs.org/downloads/point/last-month/left-pad',
+      expect.objectContaining({ spec: 'left-pad' })
+    )
+  })
+
+  test('rejects malformed public download responses', async () => {
+    const fetcher = { json: jest.fn().mockResolvedValue({ downloads: 'many' }) }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await expect(client.getDownloadInfo('left-pad')).rejects.toMatchObject({
+      name: 'RegistryError',
+      code: 'EREGISTRYPROTOCOL'
+    })
+  })
+
+  test('keeps signing-key caches isolated across registries', async () => {
+    const fetcher = {
+      json: jest
+        .fn()
+        .mockResolvedValueOnce({ keys: [{ keyid: 'public', key: 'PUBLIC' }] })
+        .mockResolvedValueOnce({ keys: [{ keyid: 'private', key: 'PRIVATE' }] })
+    }
+    const client = new RegistryClient(createConfig(), { fetcher })
+
+    await client.getRegistryKeys('left-pad')
+    await client.getRegistryKeys('@company/tool')
+
+    expect(fetcher.json).toHaveBeenCalledTimes(2)
+  })
+
+  test('never includes cause text or URL credentials in public errors', async () => {
+    const secret = 'super-secret'
+    const fetcher = {
+      json: jest
+        .fn()
+        .mockRejectedValue(
+          new Error(
+            `request failed for https://user:${secret}@artifactory.example.test/`
+          )
+        )
+    }
+    const config = createConfig({
+      registry: `https://user:${secret}@artifactory.example.test/npm/`
+    })
+    const client = new RegistryClient(config, { fetcher })
+
+    const error = await client.getPackageInfo('private-package').catch((err) => err)
+
+    expect(error).toBeInstanceOf(RegistryError)
+    expect(error.message).not.toContain(secret)
+    expect(error.registry).not.toContain(secret)
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+})

--- a/__tests__/registryConfig.test.js
+++ b/__tests__/registryConfig.test.js
@@ -107,6 +107,43 @@ describe('RegistryConfig', () => {
     ).toBe(Buffer.from('ci-password').toString('base64'))
   })
 
+  test('flattens CA, proxy, TLS, and registry-scoped client certificate options', async () => {
+    const caFile = path.join(root, 'company-ca.pem')
+    const certFile = path.join(root, 'client-cert.pem')
+    const keyFile = path.join(root, 'client-key.pem')
+    fs.writeFileSync(
+      caFile,
+      '-----BEGIN CERTIFICATE-----\nCOMPANY CA\n-----END CERTIFICATE-----\n'
+    )
+    fs.writeFileSync(certFile, 'CLIENT CERTIFICATE')
+    fs.writeFileSync(keyFile, 'CLIENT KEY')
+    fs.writeFileSync(
+      path.join(project, '.npmrc'),
+      [
+        'registry=https://secure.example.test/npm/',
+        `cafile=${caFile}`,
+        'strict-ssl=true',
+        'https-proxy=https://proxy.example.test:8443/',
+        `//secure.example.test/npm/:certfile=${certFile}`,
+        `//secure.example.test/npm/:keyfile=${keyFile}`
+      ].join('\n')
+    )
+
+    const config = await RegistryConfig.load({ env, cwd: project })
+
+    expect(config.requestOptions.ca.join('\n')).toContain('COMPANY CA')
+    expect(config.requestOptions.httpsProxy).toBe(
+      'https://proxy.example.test:8443/'
+    )
+    expect(config.requestOptions.strictSSL).toBe(true)
+    expect(
+      config.requestOptions['//secure.example.test/npm/:certfile']
+    ).toBe(certFile)
+    expect(config.requestOptions['//secure.example.test/npm/:keyfile']).toBe(
+      keyFile
+    )
+  })
+
   test('provides public npm defaults without reading config files', () => {
     const config = RegistryConfig.defaults()
 

--- a/__tests__/registryConfig.test.js
+++ b/__tests__/registryConfig.test.js
@@ -178,6 +178,21 @@ describe('RegistryConfig', () => {
     })
   })
 
+  test('reports false npm config validation results as configuration errors', async () => {
+    await expect(
+      RegistryConfig.load({
+        env: {
+          ...env,
+          npm_config_fetch_retries: 'not-a-number'
+        },
+        cwd: project
+      })
+    ).rejects.toMatchObject({
+      name: 'RegistryError',
+      code: 'EREGISTRYCONFIG'
+    })
+  })
+
   test('reports invalid unscoped authentication as a safe config error', async () => {
     fs.writeFileSync(path.join(project, '.npmrc'), '_authToken=secret-value\n')
 

--- a/__tests__/registryConfig.test.js
+++ b/__tests__/registryConfig.test.js
@@ -1,0 +1,155 @@
+'use strict'
+
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const RegistryConfig = require('../lib/helpers/registryConfig')
+
+describe('RegistryConfig', () => {
+  let root
+  let project
+  let home
+  let userConfig
+  let globalConfig
+  let env
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'npq-registry-config-'))
+    project = path.join(root, 'project')
+    home = path.join(root, 'home')
+    userConfig = path.join(root, 'user.npmrc')
+    globalConfig = path.join(root, 'global.npmrc')
+    fs.mkdirSync(project)
+    fs.mkdirSync(home)
+    fs.writeFileSync(path.join(project, 'package.json'), '{"name":"fixture"}')
+    fs.writeFileSync(
+      globalConfig,
+      'registry=https://global.example.test/npm/\n'
+    )
+    fs.writeFileSync(
+      userConfig,
+      [
+        'registry=https://user.example.test/npm/',
+        '//basic.example.test/npm/:username=ci-user',
+        `//basic.example.test/npm/:_password=${Buffer.from('ci-password').toString('base64')}`
+      ].join('\n')
+    )
+    fs.writeFileSync(
+      path.join(project, '.npmrc'),
+      [
+        'registry=https://project.example.test/npm/',
+        '@company:registry=https://scope.example.test/artifactory/api/npm/company/',
+        '//scope.example.test/artifactory/api/npm/company/:_authToken=scope-token'
+      ].join('\n')
+    )
+    env = {
+      ...process.env,
+      HOME: home,
+      npm_config_userconfig: userConfig,
+      npm_config_globalconfig: globalConfig
+    }
+    delete env.npm_config_registry
+  })
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true })
+  })
+
+  test('uses CLI registry while preserving project scoped registries and auth', async () => {
+    const config = await RegistryConfig.load({
+      argv: ['--registry=https://cli.example.test/npm/'],
+      env,
+      cwd: project
+    })
+
+    expect(config.registryFor('left-pad')).toBe(
+      'https://cli.example.test/npm/'
+    )
+    expect(config.registryFor('@company/tool')).toBe(
+      'https://scope.example.test/artifactory/api/npm/company/'
+    )
+    expect(
+      config.requestOptions[
+        '//scope.example.test/artifactory/api/npm/company/:_authToken'
+      ]
+    ).toBe('scope-token')
+    expect(config.describeRegistry('@company/tool')).not.toContain(
+      'scope-token'
+    )
+  })
+
+  test('uses environment over project and project over user and global', async () => {
+    const environmentConfig = await RegistryConfig.load({
+      env: {
+        ...env,
+        npm_config_registry: 'https://environment.example.test/npm/'
+      },
+      cwd: project
+    })
+    const projectConfig = await RegistryConfig.load({ env, cwd: project })
+
+    expect(environmentConfig.registryFor('left-pad')).toBe(
+      'https://environment.example.test/npm/'
+    )
+    expect(projectConfig.registryFor('left-pad')).toBe(
+      'https://project.example.test/npm/'
+    )
+  })
+
+  test('preserves registry scoped basic authentication fields', async () => {
+    const config = await RegistryConfig.load({ env, cwd: project })
+
+    expect(
+      config.requestOptions['//basic.example.test/npm/:username']
+    ).toBe('ci-user')
+    expect(
+      config.requestOptions['//basic.example.test/npm/:_password']
+    ).toBe(Buffer.from('ci-password').toString('base64'))
+  })
+
+  test('provides public npm defaults without reading config files', () => {
+    const config = RegistryConfig.defaults()
+
+    expect(config.requestOptions.registry).toBe(
+      'https://registry.npmjs.org/'
+    )
+    expect(config.registryFor('left-pad')).toBe(
+      'https://registry.npmjs.org/'
+    )
+  })
+
+  test('normalizes registries without trailing slashes', () => {
+    const config = new RegistryConfig({
+      registry: 'https://registry.example.test/npm'
+    })
+
+    expect(config.registryFor('left-pad')).toBe(
+      'https://registry.example.test/npm/'
+    )
+  })
+
+  test('reports invalid registry URLs as configuration errors', async () => {
+    await expect(
+      RegistryConfig.load({
+        argv: ['--registry=not a registry url'],
+        env,
+        cwd: project
+      })
+    ).rejects.toMatchObject({
+      name: 'RegistryError',
+      code: 'EREGISTRYCONFIG'
+    })
+  })
+
+  test('reports invalid unscoped authentication as a safe config error', async () => {
+    fs.writeFileSync(path.join(project, '.npmrc'), '_authToken=secret-value\n')
+
+    await expect(
+      RegistryConfig.load({ env, cwd: project })
+    ).rejects.toMatchObject({
+      name: 'RegistryError',
+      code: 'EREGISTRYCONFIGAUTH',
+      message: expect.not.stringContaining('secret-value')
+    })
+  })
+})

--- a/__tests__/reportResults.test.js
+++ b/__tests__/reportResults.test.js
@@ -763,6 +763,42 @@ describe('reportResults helper functions', () => {
   })
 })
 
+describe('not evaluated results', () => {
+  test('renders skipped checks without counting them as findings', () => {
+    const { reportResults } = require('../lib/helpers/reportResults')
+    const skippedOnlyResults = {
+      'private-package@1.0.0': [
+        {
+          signatures: {
+            status: null,
+            errors: [],
+            warnings: [],
+            notEvaluated: [
+              {
+                pkg: 'private-package@1.0.0',
+                message: 'configured registry does not expose signing keys'
+              }
+            ],
+            data: {},
+            marshall: 'signatures',
+            categoryId: 'SupplyChainSecurity'
+          }
+        }
+      ]
+    }
+
+    const result = reportResults(skippedOnlyResults, { plain: true })
+
+    expect(result.countErrors).toBe(0)
+    expect(result.countWarnings).toBe(0)
+    expect(result.countNotEvaluated).toBe(1)
+    expect(result.resultsForPlainTextPrint).toContain(
+      'NOT EVALUATED: Supply Chain Security - configured registry does not expose signing keys'
+    )
+    expect(result.summaryForPlainTextPrint).toContain('Total not evaluated: 1')
+  })
+})
+
 describe('basic functionality test', () => {
   test('functions can be imported', () => {
     const { reportResults } = require('../lib/helpers/reportResults')

--- a/bin/npq-hero.js
+++ b/bin/npq-hero.js
@@ -12,6 +12,8 @@ const cliPrompt = require('../lib/helpers/cliPrompt.js')
 const { reportResults } = require('../lib/helpers/reportResults')
 const { Spinner } = require('../lib/helpers/cliSpinner')
 const { promiseThrottleHelper } = require('../lib/helpers/promiseThrottler')
+const RegistryConfig = require('../lib/helpers/registryConfig')
+const RegistryClient = require('../lib/helpers/registryClient')
 
 const PACKAGE_MANAGER_TOOL = process.env.NPQ_PKG_MGR
 const DISABLE_AUTO_CONTINUE = process.env.NPQ_DISABLE_AUTO_CONTINUE === 'true'
@@ -27,14 +29,17 @@ if (spinner) {
   spinner.start()
 }
 
-const marshall = new Marshall({
-  pkgs: cliArgs.packages,
-  progressManager: spinner,
-  promiseThrottleHelper
-})
-
-marshall
-  .process()
+RegistryConfig.load({ argv: cliArgs.registryConfigArgs || [] })
+  .then((registryConfig) => {
+    const registryClient = new RegistryClient(registryConfig)
+    const marshall = new Marshall({
+      pkgs: cliArgs.packages,
+      registryClient,
+      progressManager: spinner,
+      promiseThrottleHelper
+    })
+    return marshall.process()
+  })
   .then((marshallResults) => {
     if (spinner) {
       spinner.stop()

--- a/bin/npq-hero.js
+++ b/bin/npq-hero.js
@@ -51,12 +51,20 @@ RegistryConfig.load({ argv: cliArgs.registryConfigArgs || [] })
       Object.hasOwn(results, 'countErrors') &&
       Object.hasOwn(results, 'countWarnings')
     ) {
-      const { countErrors, countWarnings, useRichFormatting } = results
-      const isErrors = countErrors > 0 || countWarnings > 0
+      const {
+        countErrors,
+        countWarnings,
+        countNotEvaluated = 0,
+        useRichFormatting
+      } = results
+      const hasFindings = countErrors > 0 || countWarnings > 0
+      const hasReportableResults = hasFindings || countNotEvaluated > 0
 
-      if (isErrors) {
+      if (hasReportableResults) {
         console.log()
-        console.log('Packages with issues found:')
+        console.log(
+          hasFindings ? 'Packages with issues found:' : 'Package checks not evaluated:'
+        )
 
         if (useRichFormatting) {
           console.log(results.resultsForPrettyPrint)
@@ -68,9 +76,10 @@ RegistryConfig.load({ argv: cliArgs.registryConfigArgs || [] })
       }
 
       return {
-        anyIssues: isErrors,
+        anyIssues: hasFindings,
         countErrors,
-        countWarnings
+        countWarnings,
+        countNotEvaluated
       }
     }
     return undefined

--- a/bin/npq.js
+++ b/bin/npq.js
@@ -73,12 +73,20 @@ RegistryConfig.load({ argv: cliArgs.registryConfigArgs || [] })
       Object.hasOwn(results, 'countErrors') &&
       Object.hasOwn(results, 'countWarnings')
     ) {
-      const { countErrors, countWarnings, useRichFormatting } = results
-      const isErrors = countErrors > 0 || countWarnings > 0
+      const {
+        countErrors,
+        countWarnings,
+        countNotEvaluated = 0,
+        useRichFormatting
+      } = results
+      const hasFindings = countErrors > 0 || countWarnings > 0
+      const hasReportableResults = hasFindings || countNotEvaluated > 0
 
-      if (isErrors) {
+      if (hasReportableResults) {
         console.log()
-        console.log('Packages with issues found:')
+        console.log(
+          hasFindings ? 'Packages with issues found:' : 'Package checks not evaluated:'
+        )
 
         if (useRichFormatting) {
           console.log(results.resultsForPrettyPrint)
@@ -90,9 +98,10 @@ RegistryConfig.load({ argv: cliArgs.registryConfigArgs || [] })
       }
 
       return {
-        anyIssues: isErrors,
+        anyIssues: hasFindings,
         countErrors,
-        countWarnings
+        countWarnings,
+        countNotEvaluated
       }
     }
     return undefined

--- a/bin/npq.js
+++ b/bin/npq.js
@@ -15,6 +15,8 @@ const cliPrompt = require('../lib/helpers/cliPrompt.js')
 const { reportResults } = require('../lib/helpers/reportResults')
 const { Spinner } = require('../lib/helpers/cliSpinner')
 const { promiseThrottleHelper } = require('../lib/helpers/promiseThrottler')
+const RegistryConfig = require('../lib/helpers/registryConfig')
+const RegistryClient = require('../lib/helpers/registryClient')
 
 const debug = util.debuglog('npq')
 
@@ -27,7 +29,12 @@ if (spinner) {
   spinner.start()
 }
 
-Promise.resolve()
+let registryClient
+
+RegistryConfig.load({ argv: cliArgs.registryConfigArgs || [] })
+  .then((registryConfig) => {
+    registryClient = new RegistryClient(registryConfig)
+  })
   .then(() => {
     if (cliArgs.packages.length === 0) {
       debug('\nNo packages specified, using project packages from package.json')
@@ -48,6 +55,7 @@ Promise.resolve()
 
     const marshall = new Marshall({
       pkgs: packages,
+      registryClient,
       progressManager: spinner,
       promiseThrottleHelper
     })

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ The `feature/` directory contains detailed documentation for specific features a
 ### Existing Features  
 
 - **`auto-continue.md`** - Documentation for the auto-continue feature that streamlines package installation workflows
+- **`custom-registry.md`** - Authenticated default and scoped npm-compatible registry configuration, routing, and failure behavior
 - **`exit-codes.md`** - Reference for `npq` and `npq-hero` process exit behavior
 - **`malicious-package.md`** - Documentation for known-malicious package detection through Snyk/OSV data
 - **`pacote-dependency-reduction.md`** - Implementation summary for optional pacote dependency reduction
@@ -70,6 +71,7 @@ When adding new features or making significant changes:
 | Test Coverage | `feature/test-coverage-improvements.md` | Recent test suite enhancements |
 | Signature Verification | `feature/signature-verification-fix.md` | Version range bug fix and validation |
 | Auto-Continue | `feature/auto-continue.md` | Automated installation workflow |
+| Custom Registries | `feature/custom-registry.md` | Authenticated npm-compatible registry configuration and privacy behavior |
 | Exit Codes | `feature/exit-codes.md` | CLI and package-manager passthrough exit behavior |
 | Malicious Packages | `feature/malicious-package.md` | Known-malicious package detection and reporting |
 | Dependency Reduction | `feature/pacote-dependency-reduction.md` | Optional dependency management |

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,3 +84,7 @@ When adding new features or making significant changes:
 ## Design specifications
 
 - [Custom registry support](./superpowers/specs/2026-07-11-custom-registry-support-design.md) - approved design for npm-compatible Artifactory and private registry support.
+
+## Implementation plans
+
+- [Custom registry support](./superpowers/plans/2026-07-11-custom-registry-support.md) - task-by-task implementation plan for issue #429.

--- a/docs/README.md
+++ b/docs/README.md
@@ -80,3 +80,7 @@ When adding new features or making significant changes:
 - [Testing](./testing.md) - test commands, test organization, and verification expectations.
 - [Architecture](./architecture.md) - repository structure, package boundaries, and important flows.
 - [Conventions](./conventions.md) - coding, documentation, and maintenance conventions.
+
+## Design specifications
+
+- [Custom registry support](./superpowers/specs/2026-07-11-custom-registry-support-design.md) - approved design for npm-compatible Artifactory and private registry support.

--- a/docs/feature/custom-registry.md
+++ b/docs/feature/custom-registry.md
@@ -1,0 +1,72 @@
+# Custom registries
+
+NPQ supports authenticated npm-compatible registries, including Artifactory, for both package metadata and registry-backed security checks. It reads the same standard npm configuration used by the package manager, so registry routing, authentication, proxies, and TLS settings remain consistent between auditing and installation.
+
+## Configure a default registry
+
+Set the registry and host/path-scoped token in an npm configuration file such as a project or user `.npmrc`:
+
+```ini
+registry=https://artifactory.example.com/artifactory/api/npm/npm-virtual/
+//artifactory.example.com/artifactory/api/npm/npm-virtual/:_authToken=${ARTIFACTORY_TOKEN}
+```
+
+NPQ also accepts the standard CLI option. The option is used for the audit and is forwarded to the selected package manager:
+
+```sh
+npq install internal-tool --registry=https://artifactory.example.com/artifactory/api/npm/npm-virtual/
+```
+
+## Configure a scoped registry
+
+Map a package scope to its registry and scope authentication to that registry's host and path:
+
+```ini
+@company:registry=https://artifactory.example.com/artifactory/api/npm/company/
+//artifactory.example.com/artifactory/api/npm/company/:_authToken=${ARTIFACTORY_TOKEN}
+```
+
+With this configuration, `@company/tool` is audited against the company registry even when the default registry points elsewhere.
+
+Never commit registry tokens. Prefer environment-variable substitution or a user-level npm configuration file, and make authentication keys as specific as the registry host and path allow. NPQ does not include credentials in user-facing registry errors.
+
+## Configuration precedence
+
+NPQ follows npm's configuration precedence, from highest to lowest:
+
+1. Command-line options such as `--registry`
+2. `npm_config_*` environment variables
+3. Project `.npmrc`
+4. User `.npmrc`
+5. Global npm configuration
+6. The public npm registry default
+
+A scoped registry such as `@company:registry` is selected for that scope independently of the unscoped default registry.
+
+## TLS, proxies, and client certificates
+
+Standard npm network settings are supported. For example, a private certificate authority can be configured with:
+
+```ini
+cafile=/absolute/path/to/company-ca.pem
+strict-ssl=true
+```
+
+NPQ also preserves npm's `proxy`, `https-proxy`, and registry-scoped `certfile` and `keyfile` settings. Client certificate and authentication settings apply through npm's registry client only to matching registry hosts and paths.
+
+## Checks that may not be evaluated
+
+Some npm-compatible registries do not implement every public npm service. NPQ reports these cases as `NOT EVALUATED` rather than silently passing or treating them as package findings:
+
+- `signatures` when the selected registry does not expose signing keys;
+- `provenance` when signing keys or attestations are unavailable;
+- `downloads` for packages assigned to a custom registry, because public npm download counts do not describe private registry usage.
+
+Skipped checks do not trigger a warning/error prompt and do not fail audit-only mode. Any warnings or errors found by other checks retain their normal behavior.
+
+An unavailable optional endpoint is recognized when it responds with HTTP 404, 405, or 501. Authentication failures, network failures, server errors, and malformed registry responses remain fatal because NPQ cannot safely complete the audit.
+
+## No public-registry fallback
+
+NPQ never falls back to `registry.npmjs.org` or the public npm downloads service for a package assigned to a custom registry. Package metadata, manifests, signing keys, and attestations stay within the selected registry context. This avoids both incorrect audit results and disclosure of private package names to public npm services.
+

--- a/docs/superpowers/plans/2026-07-11-custom-registry-support.md
+++ b/docs/superpowers/plans/2026-07-11-custom-registry-support.md
@@ -1,0 +1,1612 @@
+# Custom Registry Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make npq audit packages through authenticated default or scoped registries selected by standard npm configuration, without silently falling back to npmjs.
+
+**Architecture:** Load npm-compatible configuration once with `@npmcli/config`, pass its flattened options to a single `RegistryClient` built on `npm-registry-fetch`, and inject that client through the CLI, `Marshall`, metadata helpers, and registry-dependent marshalls. Represent unavailable optional registry services with a visible `notEvaluated` result, while configuration, authentication, transport, and protocol failures abort the audit.
+
+**Tech Stack:** CommonJS on Node.js 24, npm 11.10 or newer, Jest 30, `@npmcli/config@^10.8.1`, `npm-registry-fetch@^19.1.1`, existing `npm-package-arg`, `semver`, `sigstore`, and `ssri`.
+
+## Global Constraints
+
+- Preserve the existing default registry `https://registry.npmjs.org/`.
+- Standard configuration precedence is CLI, environment, project, user, global, then npm-compatible defaults.
+- Support default and scoped registries, registry-scoped authentication, proxy, CA, client certificate, and strict-TLS settings.
+- Do not add `NPQ_REGISTRY`, `--npq-registry`, native `.yarnrc.yml` parsing, Artifactory administration APIs, or registry-specific analytics.
+- A package assigned to a custom registry must cause zero package-registry or download requests to npmjs.
+- Never send authentication material to a registry host or path that does not match its npm configuration scope.
+- Optional signing-key, attestation, and download-service absence is visible as `notEvaluated` and does not affect warning/error counts, prompts, auto-continue, or exit status.
+- Authentication, TLS, proxy, DNS, timeout, server, malformed metadata, malformed optional responses, and invalid configuration failures abort the audit.
+- Preserve current package-level signature, provenance, provenance-regression, and download-count severities when their required services are available.
+- Every behavior change is test-first, and every task ends in an independently reviewable Conventional Commit.
+
+---
+
+## File Structure
+
+### New runtime files
+
+- `lib/helpers/notEvaluated.js` — typed signal for checks that cannot run because a registry capability is absent.
+- `lib/helpers/registryErrors.js` — fatal registry error type plus registry URL sanitization.
+- `lib/helpers/registryConfig.js` — npm configuration loading, validation, precedence, flattening, and package-specific registry selection.
+- `lib/helpers/registryClient.js` — the only npm-registry HTTP client; owns metadata, keys, attestation, download, and capability-cache behavior.
+
+### New test files
+
+- `__tests__/__fixtures__/fatalRegistry.marshall.js` — deterministic fatal registry marshall for task-runner propagation tests.
+- `__tests__/registryConfig.test.js` — real temporary `.npmrc` hierarchy and option-flattening tests.
+- `__tests__/registryClient.test.js` — mocked transport tests for routing, auth isolation, failure classification, capability caching, and redaction.
+- `__tests__/customRegistry.integration.test.js` — configuration-to-client-to-marshall integration without live network access.
+
+### Existing runtime files to modify
+
+- `package.json`, `package-lock.json` — add the two maintained npm runtime libraries.
+- `lib/cli.js` — parse supported standard registry flags and expose isolated config arguments.
+- `bin/npq.js`, `bin/npq-hero.js` — load registry configuration before constructing `Marshall`; print skipped checks without treating them as findings.
+- `lib/marshall.js` — accept/inject one `RegistryClient`.
+- `lib/helpers/packageRepoUtils.js` — delegate registry network work and key caches by registry plus package.
+- `lib/helpers/npmRegistry.js` — retain cryptographic verification only; accept fetched attestations.
+- `lib/marshalls/baseMarshall.js` — record `notEvaluated` and rethrow fatal registry failures.
+- `lib/marshalls/index.js` — inject the registry client and propagate fatal registry failures.
+- `lib/marshalls/signatures.marshall.js`, `lib/marshalls/provenance.marshall.js` — use the injected client and remove hard-coded endpoints.
+- `lib/helpers/reportResults.js` — aggregate and render `notEvaluated` without changing warning/error totals.
+
+### Existing tests to modify
+
+- `__tests__/cli.parser.complete.test.js`, `__tests__/cli.test.js`, `__tests__/exitCode.test.js` — registry arguments, startup loading, output, prompts, and exit behavior.
+- `__tests__/packageManager.test.js` — standard registry flags remain forwarded to the package manager.
+- `__tests__/packageRepoUtils.test.js` — registry-client delegation and cache isolation.
+- `__tests__/npmRegistry.test.js` — verification-only interface.
+- `__tests__/marshalls.base.test.js`, `__tests__/marshalls.tasks.test.js` — skipped and fatal result propagation.
+- `__tests__/marshalls.signatures.test.js`, `__tests__/marshalls.provenance.test.js`, `__tests__/marshalls.downloads.test.js` — injected client behavior.
+- `__tests__/reportResults.test.js` — visible skipped checks and unchanged finding counts.
+
+### Documentation and release files
+
+- `docs/feature/custom-registry.md` — user-facing setup, behavior, security, and limitations.
+- `README.md`, `docs/README.md` — link and summarize the feature.
+- `.changeset/bright-tools-audit.md` — minor release note required by `RELEASE.md`.
+
+---
+
+### Task 1: Add skipped-check and fatal-registry result primitives
+
+**Files:**
+- Create: `lib/helpers/notEvaluated.js`
+- Create: `lib/helpers/registryErrors.js`
+- Create: `__tests__/__fixtures__/fatalRegistry.marshall.js`
+- Modify: `lib/marshalls/baseMarshall.js:1-62`
+- Modify: `lib/marshalls/index.js:20-49`
+- Modify: `lib/helpers/reportResults.js:82-307`
+- Test: `__tests__/marshalls.base.test.js`
+- Test: `__tests__/marshalls.tasks.test.js`
+- Test: `__tests__/reportResults.test.js`
+
+**Interfaces:**
+- Produces: `new NotEvaluated(message, { capability })`.
+- Produces: `new RegistryError(message, { registry, code, statusCode, cause })`.
+- Produces: `sanitizeRegistryUrl(value): string`.
+- Produces: marshall results with `notEvaluated: Array<{pkg, message}>`.
+- Produces: report output with `countNotEvaluated: number`; warning and error counts remain independent.
+
+- [ ] **Step 1: Write failing BaseMarshall and task-propagation tests**
+
+Append these cases to `__tests__/marshalls.base.test.js`:
+
+```js
+test('checkPackage records NotEvaluated separately from findings', async () => {
+  const NotEvaluated = require('../lib/helpers/notEvaluated')
+  const marshall = new BaseMarshall({ packageRepoUtils: null })
+  marshall.name = 'optional'
+  marshall.validate = jest.fn().mockRejectedValue(
+    new NotEvaluated('configured registry does not expose signing keys', {
+      capability: 'signing-keys'
+    })
+  )
+  const ctx = { pkgs: [], marshalls: {} }
+  marshall.init(ctx)
+
+  await marshall.checkPackage({ packageString: 'private-package@1.0.0' }, ctx)
+
+  expect(ctx.marshalls.optional.errors).toEqual([])
+  expect(ctx.marshalls.optional.warnings).toEqual([])
+  expect(ctx.marshalls.optional.notEvaluated).toEqual([
+    {
+      pkg: 'private-package@1.0.0',
+      message: 'configured registry does not expose signing keys'
+    }
+  ])
+})
+
+test('checkPackage rethrows fatal RegistryError', async () => {
+  const { RegistryError } = require('../lib/helpers/registryErrors')
+  const marshall = new BaseMarshall({ packageRepoUtils: null })
+  marshall.name = 'optional'
+  marshall.validate = jest.fn().mockRejectedValue(
+    new RegistryError('Registry authentication failed', {
+      registry: 'https://user:secret@artifactory.example.test/api/npm/npm/',
+      code: 'EREGISTRYAUTH',
+      statusCode: 401
+    })
+  )
+  const ctx = { pkgs: [], marshalls: {} }
+  marshall.init(ctx)
+
+  await expect(
+    marshall.checkPackage({ packageString: 'private-package@1.0.0' }, ctx)
+  ).rejects.toMatchObject({ code: 'EREGISTRYAUTH', statusCode: 401 })
+})
+```
+
+Create `__tests__/__fixtures__/fatalRegistry.marshall.js`:
+
+```js
+'use strict'
+
+const BaseMarshall = require('../../lib/marshalls/baseMarshall')
+const { RegistryError } = require('../../lib/helpers/registryErrors')
+
+class FatalRegistryMarshall extends BaseMarshall {
+  constructor(options) {
+    super(options)
+    this.name = 'fatal-registry'
+  }
+
+  title() {
+    return 'Testing fatal registry propagation'
+  }
+
+  validate() {
+    return Promise.reject(
+      new RegistryError('Registry network request failed', {
+        registry: 'https://artifactory.example.test/api/npm/npm/',
+        code: 'EREGISTRYNETWORK'
+      })
+    )
+  }
+}
+
+module.exports = FatalRegistryMarshall
+```
+
+In `__tests__/marshalls.tasks.test.js`, use:
+
+```js
+marshalls.collectMarshalls = jest.fn().mockResolvedValue([
+  path.join(
+    process.cwd(),
+    '__tests__/__fixtures__/fatalRegistry.marshall.js'
+  )
+])
+const config = {
+  pkgs: [{ packageName: 'private-package', packageString: 'private-package@1.0.0' }],
+  packageRepoUtils: new PackageRepoUtilsMock()
+}
+
+await expect(marshalls.tasks(config)).rejects.toMatchObject({
+  name: 'RegistryError',
+  code: 'EREGISTRYNETWORK'
+})
+```
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/marshalls.base.test.js __tests__/marshalls.tasks.test.js
+```
+
+Expected: FAIL because `notEvaluated`, `NotEvaluated`, and `RegistryError` do not exist.
+
+- [ ] **Step 3: Add the two error primitives**
+
+Create `lib/helpers/notEvaluated.js`:
+
+```js
+'use strict'
+
+class NotEvaluated extends Error {
+  constructor(message, { capability = null } = {}) {
+    super(message)
+    this.name = 'NotEvaluated'
+    this.capability = capability
+  }
+}
+
+module.exports = NotEvaluated
+```
+
+Create `lib/helpers/registryErrors.js`:
+
+```js
+'use strict'
+
+function sanitizeRegistryUrl(value) {
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return 'configured registry'
+  }
+}
+
+class RegistryError extends Error {
+  constructor(
+    message,
+    { registry = null, code = 'EREGISTRY', statusCode = null, cause = null } = {}
+  ) {
+    const sanitizedRegistry = registry ? sanitizeRegistryUrl(registry) : null
+    super(sanitizedRegistry ? `${message} (${sanitizedRegistry})` : message, {
+      cause: cause || undefined
+    })
+    this.name = 'RegistryError'
+    this.code = code
+    this.statusCode = statusCode
+    this.registry = sanitizedRegistry
+  }
+}
+
+module.exports = { RegistryError, sanitizeRegistryUrl }
+```
+
+- [ ] **Step 4: Teach BaseMarshall and the task runner the new states**
+
+In `BaseMarshall.init()`, initialize:
+
+```js
+notEvaluated: [],
+```
+
+Replace `BaseMarshall.checkPackage()` with:
+
+```js
+checkPackage(pkg, ctx) {
+  return this.validate(pkg)
+    .then((data) => {
+      ctx.marshalls[this.name].data[pkg.packageString] = data
+      return data
+    })
+    .catch((err) => {
+      const NotEvaluated = require('../helpers/notEvaluated')
+      const { RegistryError } = require('../helpers/registryErrors')
+
+      if (err instanceof RegistryError) {
+        throw err
+      }
+
+      const message = {
+        pkg: pkg.packageString,
+        message: err.message
+      }
+
+      if (err instanceof NotEvaluated) {
+        this.setNotEvaluated(message)
+        return undefined
+      }
+
+      this.setMessage(message, Boolean(err instanceof Warning))
+      return undefined
+    })
+}
+
+setNotEvaluated(msg) {
+  this.ctx.marshalls[this.name].notEvaluated.push({
+    pkg: msg.pkg,
+    message: msg.message
+  })
+}
+```
+
+Move the two new `require` calls to the import section after the tests pass, preserving the method body shown above without dynamic imports.
+
+In the `Marshalls.tasks()` marshall-execution catch block, add fatal propagation:
+
+```js
+} catch (error) {
+  if (error instanceof RegistryError) {
+    throw error
+  }
+  console.error(`Error running task ${marshall.title}:`, error)
+}
+```
+
+Import `RegistryError` once at the top of `lib/marshalls/index.js`. Add `notEvaluated: []` to the synthetic `not_found` result so every marshall result has the same shape.
+
+- [ ] **Step 5: Add failing report tests for visible skipped checks**
+
+Add a report fixture containing only:
+
+```js
+const skippedOnlyResults = {
+  'private-package@1.0.0': [
+    {
+      signatures: {
+        status: null,
+        errors: [],
+        warnings: [],
+        notEvaluated: [
+          {
+            pkg: 'private-package@1.0.0',
+            message: 'configured registry does not expose signing keys'
+          }
+        ],
+        data: {},
+        marshall: 'signatures',
+        categoryId: 'SupplyChainSecurity'
+      }
+    }
+  ]
+}
+```
+
+Assert:
+
+```js
+const result = reportResults(skippedOnlyResults, { plain: true })
+expect(result.countErrors).toBe(0)
+expect(result.countWarnings).toBe(0)
+expect(result.countNotEvaluated).toBe(1)
+expect(result.resultsForPlainTextPrint).toContain(
+  'NOT EVALUATED: Supply Chain Security - configured registry does not expose signing keys'
+)
+expect(result.summaryForPlainTextPrint).toContain('Total not evaluated: 1')
+```
+
+- [ ] **Step 6: Implement report aggregation and rendering**
+
+Initialize `countNotEvaluated = 0`. Add `notEvaluated: []` to each package created by `marshallResultsToIssuesPerPackage()`. Map marshall entries exactly like warnings:
+
+```js
+if (value.notEvaluated && value.notEvaluated.length > 0) {
+  const skippedChecks = value.notEvaluated.map((entry) => ({
+    marshall: value.marshall,
+    categoryId: value.categoryId,
+    categoryFriendlyName: marshallCategories[value.categoryId].title,
+    ...entry
+  }))
+  issues.notEvaluated.push(skippedChecks)
+}
+```
+
+Retain packages when any of errors, warnings, or skipped checks exist:
+
+```js
+if (
+  issues.errors.length > 0 ||
+  issues.warnings.length > 0 ||
+  issues.notEvaluated.length > 0
+) {
+  issuesPerPackage.push(issues)
+}
+```
+
+Render skipped checks after warnings using a cyan `○` in rich output and this stable plain-text format:
+
+```js
+if (result.notEvaluated && result.notEvaluated.length > 0) {
+  result.notEvaluated.forEach((entryArray) => {
+    countNotEvaluated += entryArray.length
+    entryArray.forEach((entry) => {
+      const topicRich = styleText(
+        ['cyan'],
+        entry.categoryFriendlyName.padEnd(maxTextLength, ' ')
+      )
+      const iconRich = styleText(['cyan'], '○')
+      const wrappedMessage = wrapTextWithIndent(
+        entry.message,
+        maxMessageWidth,
+        indentString
+      )
+      resultsForPrettyPrint +=
+        `\n ${prefixRich} ${iconRich} ${topicRich} ${separatorRich} ${wrappedMessage} `
+      resultsForPlainTextPrint +=
+        `\n  NOT EVALUATED: ${entry.categoryFriendlyName} - ${entry.message}`
+    })
+  })
+}
+```
+
+Add `Total not evaluated` to both summaries and return `countNotEvaluated`.
+
+- [ ] **Step 7: Run tests and commit**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/marshalls.base.test.js __tests__/marshalls.tasks.test.js __tests__/reportResults.test.js
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add lib/helpers/notEvaluated.js lib/helpers/registryErrors.js lib/marshalls/baseMarshall.js lib/marshalls/index.js lib/helpers/reportResults.js __tests__/__fixtures__/fatalRegistry.marshall.js __tests__/marshalls.base.test.js __tests__/marshalls.tasks.test.js __tests__/reportResults.test.js
+git commit -m "feat: represent registry checks that cannot be evaluated"
+```
+
+---
+
+### Task 2: Load standard npm registry configuration
+
+**Files:**
+- Create: `lib/helpers/registryConfig.js`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+- Modify: `lib/cli.js:63-153`
+- Test: `__tests__/registryConfig.test.js`
+- Test: `__tests__/cli.parser.complete.test.js`
+
+**Interfaces:**
+- Produces: `RegistryConfig.load({ argv, env, cwd }): Promise<RegistryConfig>`.
+- Produces: `RegistryConfig.defaults(): RegistryConfig`.
+- Produces: `registryConfig.requestOptions: Readonly<object>`.
+- Produces: `registryConfig.registryFor(packageSpec): string`.
+- Produces: `registryConfig.describeRegistry(packageSpec): string`.
+- Produces: `cliArgs.registryConfigArgs: string[]` for both parsers.
+
+- [ ] **Step 1: Install exact compatible dependency ranges**
+
+Run:
+
+```bash
+npm install '@npmcli/config@^10.8.1' 'npm-registry-fetch@^19.1.1'
+```
+
+Expected: `package.json` contains both packages in `dependencies`, `package-lock.json` is updated, and npm reports no engine incompatibility on Node.js 24.
+
+- [ ] **Step 2: Write failing configuration hierarchy tests**
+
+Create `__tests__/registryConfig.test.js` using `fs.mkdtempSync`, `fs.writeFileSync`, and isolated `HOME`, `npm_config_userconfig`, and `npm_config_globalconfig` paths. Include these assertions:
+
+```js
+const config = await RegistryConfig.load({
+  argv: ['--registry=https://cli.example.test/npm/'],
+  env: {
+    ...process.env,
+    HOME: home,
+    npm_config_userconfig: userConfig,
+    npm_config_globalconfig: globalConfig
+  },
+  cwd: project
+})
+
+expect(config.registryFor('left-pad')).toBe('https://cli.example.test/npm/')
+expect(config.registryFor('@company/tool')).toBe(
+  'https://scope.example.test/artifactory/api/npm/company/'
+)
+expect(config.requestOptions['//scope.example.test/artifactory/api/npm/company/:_authToken'])
+  .toBe('scope-token')
+expect(config.describeRegistry('@company/tool')).not.toContain('scope-token')
+```
+
+Write project, user, and global files with different `registry` values, a scoped registry, and a registry-scoped token. Add separate tests proving environment overrides project and project overrides user/global. Add:
+
+```js
+expect(config.requestOptions[
+  '//basic.example.test/npm/:username'
+]).toBe('ci-user')
+expect(config.requestOptions[
+  '//basic.example.test/npm/:_password'
+]).toBe(Buffer.from('ci-password').toString('base64'))
+expect(() => RegistryConfig.defaults().requestOptions.registry).not.toThrow()
+expect(RegistryConfig.defaults().registryFor('left-pad')).toBe(
+  'https://registry.npmjs.org/'
+)
+```
+
+- [ ] **Step 3: Run the new test and verify it fails**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/registryConfig.test.js
+```
+
+Expected: FAIL because `lib/helpers/registryConfig.js` does not exist.
+
+- [ ] **Step 4: Implement RegistryConfig**
+
+Create `lib/helpers/registryConfig.js`:
+
+```js
+'use strict'
+
+const path = require('node:path')
+const Config = require('@npmcli/config')
+const npmFetch = require('npm-registry-fetch')
+const {
+  definitions,
+  flatten,
+  nerfDarts,
+  shorthands
+} = require('@npmcli/config/lib/definitions')
+const { RegistryError, sanitizeRegistryUrl } = require('./registryErrors')
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/'
+
+function normalizeRegistry(value) {
+  const url = new URL(value || DEFAULT_REGISTRY)
+  if (!url.pathname.endsWith('/')) {
+    url.pathname += '/'
+  }
+  return url.toString()
+}
+
+class RegistryConfig {
+  constructor(requestOptions) {
+    this.requestOptions = Object.freeze({
+      ...requestOptions,
+      registry: normalizeRegistry(requestOptions.registry)
+    })
+  }
+
+  static defaults() {
+    return new RegistryConfig({ registry: DEFAULT_REGISTRY })
+  }
+
+  static async load({
+    argv = [],
+    env = process.env,
+    cwd = process.cwd()
+  } = {}) {
+    try {
+      const config = new Config({
+        npmPath: path.resolve(__dirname, '../..'),
+        definitions,
+        shorthands,
+        flatten,
+        nerfDarts,
+        argv: ['node', 'npq', ...argv],
+        env,
+        cwd,
+        warn: false
+      })
+      await config.load()
+      config.validate()
+      return new RegistryConfig(config.flat)
+    } catch (error) {
+      const code =
+        error.code === 'ERR_INVALID_AUTH'
+          ? 'EREGISTRYCONFIGAUTH'
+          : 'EREGISTRYCONFIG'
+      const message =
+        error.code === 'ERR_INVALID_AUTH'
+          ? 'Invalid npm registry authentication configuration'
+          : `Unable to load npm registry configuration: ${error.code || error.name}`
+      throw new RegistryError(message, { code, cause: error })
+    }
+  }
+
+  registryFor(packageSpec) {
+    return normalizeRegistry(
+      npmFetch.pickRegistry(packageSpec, this.requestOptions)
+    )
+  }
+
+  describeRegistry(packageSpec) {
+    return sanitizeRegistryUrl(this.registryFor(packageSpec))
+  }
+}
+
+module.exports = RegistryConfig
+```
+
+- [ ] **Step 5: Write failing CLI parsing tests**
+
+In `__tests__/cli.parser.complete.test.js`, make the mocked parser return:
+
+```js
+values: {
+  registry: 'https://artifactory.example.test/api/npm/npm/',
+  userconfig: '/tmp/user.npmrc',
+  globalconfig: '/tmp/global.npmrc'
+}
+```
+
+Assert both `parseArgsFull()` and `parseArgsMinimal()` return:
+
+```js
+registryConfigArgs: [
+  '--registry=https://artifactory.example.test/api/npm/npm/',
+  '--userconfig=/tmp/user.npmrc',
+  '--globalconfig=/tmp/global.npmrc'
+]
+```
+
+Update every exact parser-result assertion to include `registryConfigArgs: []` when none are supplied.
+
+- [ ] **Step 6: Extend the CLI parser without consuming package-manager forwarding**
+
+Add these options to both parser option maps:
+
+```js
+registry: { type: 'string' },
+userconfig: { type: 'string' },
+globalconfig: { type: 'string' }
+```
+
+Add:
+
+```js
+static registryConfigArgs(values = {}) {
+  return ['registry', 'userconfig', 'globalconfig'].flatMap((key) =>
+    values[key] ? [`--${key}=${values[key]}`] : []
+  )
+}
+```
+
+Return `registryConfigArgs: this.registryConfigArgs(values)` from both parser methods. In `parseArgsMinimal()`, destructure `values` as well as `positionals`. Add the three standard flags to the help output. Do not remove them from `process.argv`; `packageManager.spawnPackageManager()` must continue forwarding them.
+
+- [ ] **Step 7: Run tests and commit**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/registryConfig.test.js __tests__/cli.parser.complete.test.js
+npm run lint
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add package.json package-lock.json lib/helpers/registryConfig.js lib/cli.js __tests__/registryConfig.test.js __tests__/cli.parser.complete.test.js
+git commit -m "feat: load npm-compatible registry configuration"
+```
+
+---
+
+### Task 3: Centralize registry HTTP behavior
+
+**Files:**
+- Create: `lib/helpers/registryClient.js`
+- Test: `__tests__/registryClient.test.js`
+
+**Interfaces:**
+- Consumes: `RegistryConfig.requestOptions`, `RegistryConfig.registryFor(spec)`, `NotEvaluated`, and `RegistryError`.
+- Produces: `RegistryClient.public(): RegistryClient`.
+- Produces: `registryFor(packageSpec): string`.
+- Produces: `getPackageInfo(packageName): Promise<object | {error: 'Not found'}>`.
+- Produces: `getManifest(packageSpec, packument): Promise<object>`.
+- Produces: `getRegistryKeys(packageSpec): Promise<Array<object>>`.
+- Produces: `getAttestations(packageSpec, manifest): Promise<Array<object>>`.
+- Produces: `getDownloadInfo(packageName): Promise<number>`.
+
+- [ ] **Step 1: Write failing routing and failure-classification tests**
+
+Create an injected fetcher:
+
+```js
+const fetcher = {
+  json: jest.fn()
+}
+const config = new RegistryConfig({
+  registry: 'https://registry.npmjs.org/',
+  '@company:registry':
+    'https://artifactory.example.test/api/npm/company/'
+})
+const client = new RegistryClient(config, { fetcher })
+```
+
+Cover:
+
+```js
+await client.getPackageInfo('@company/tool')
+expect(fetcher.json).toHaveBeenCalledWith('@company%2ftool', expect.objectContaining({
+  spec: '@company/tool',
+  registry: 'https://registry.npmjs.org/',
+  '@company:registry': 'https://artifactory.example.test/api/npm/company/'
+}))
+```
+
+Also test:
+
+- package metadata `404` returns `{ error: 'Not found' }`;
+- metadata `401`, `403`, `500`, and rejected network calls throw `RegistryError`;
+- optional `404`, `405`, and `501` throw `NotEvaluated`;
+- empty signing-key arrays are cached as unavailable;
+- malformed successful JSON throws `RegistryError`;
+- a custom registry download check throws `NotEvaluated` without calling `fetcher.json`;
+- a public registry download check calls `https://api.npmjs.org/downloads/point/last-month/<escaped-name>`;
+- registry keys are cached separately for two scopes;
+- an advertised `https://registry.npmjs.org/-/npm/v1/attestations/pkg@1.0.0` URL is requested as the relative path `-/npm/v1/attestations/pkg@1.0.0` with the Artifactory package spec.
+
+- [ ] **Step 2: Run the client test and verify it fails**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/registryClient.test.js
+```
+
+Expected: FAIL because `RegistryClient` does not exist.
+
+- [ ] **Step 3: Implement RegistryClient**
+
+Create `lib/helpers/registryClient.js` with this complete public shape and helpers:
+
+```js
+'use strict'
+
+const npa = require('npm-package-arg')
+const npmFetch = require('npm-registry-fetch')
+const NotEvaluated = require('./notEvaluated')
+const RegistryConfig = require('./registryConfig')
+const { RegistryError } = require('./registryErrors')
+
+const PUBLIC_REGISTRY = 'https://registry.npmjs.org/'
+const OPTIONAL_STATUS = new Set([404, 405, 501])
+const CAPABILITY = Object.freeze({
+  SIGNING_KEYS: 'signing-keys',
+  ATTESTATIONS: 'attestations',
+  DOWNLOAD_COUNTS: 'download-counts'
+})
+const CAPABILITY_MESSAGE = Object.freeze({
+  [CAPABILITY.SIGNING_KEYS]:
+    'configured registry does not expose signing keys',
+  [CAPABILITY.ATTESTATIONS]:
+    'configured registry does not expose attestations',
+  [CAPABILITY.DOWNLOAD_COUNTS]:
+    'download counts are available only for the public npm registry'
+})
+
+class RegistryClient {
+  constructor(registryConfig, { fetcher = npmFetch } = {}) {
+    this.registryConfig = registryConfig
+    this.fetcher = fetcher
+    this.keyCache = new Map()
+    this.capabilityCache = new Map()
+  }
+
+  static public() {
+    return new RegistryClient(RegistryConfig.defaults())
+  }
+
+  registryFor(packageSpec) {
+    return this.registryConfig.registryFor(packageSpec)
+  }
+
+  requestOptions(packageSpec) {
+    return {
+      ...this.registryConfig.requestOptions,
+      spec: packageSpec,
+      headers: {
+        accept: 'application/json',
+        'user-agent': 'npq-npm-registry-client'
+      }
+    }
+  }
+
+  async requestJson(
+    requestPath,
+    packageSpec,
+    { capability = null, notFoundAsData = false } = {}
+  ) {
+    const registry = this.registryFor(packageSpec)
+    try {
+      return await this.fetcher.json(
+        requestPath,
+        this.requestOptions(packageSpec)
+      )
+    } catch (error) {
+      const statusCode = error.statusCode || error.status || null
+      if (notFoundAsData && statusCode === 404) {
+        return { error: 'Not found' }
+      }
+      if (capability && OPTIONAL_STATUS.has(statusCode)) {
+        this.capabilityCache.set(`${registry}|${capability}`, false)
+        throw new NotEvaluated(CAPABILITY_MESSAGE[capability], { capability })
+      }
+      const code =
+        statusCode === 401 || statusCode === 403
+          ? 'EREGISTRYAUTH'
+          : statusCode
+            ? 'EREGISTRYHTTP'
+            : 'EREGISTRYNETWORK'
+      throw new RegistryError(
+        statusCode === 401 || statusCode === 403
+          ? 'Registry authentication or authorization failed'
+          : statusCode
+            ? `Registry request failed with HTTP ${statusCode}`
+            : 'Registry network request failed',
+        { registry, code, statusCode, cause: error }
+      )
+    }
+  }
+
+  async getPackageInfo(packageName) {
+    const spec = npa(packageName)
+    const data = await this.requestJson(spec.escapedName, packageName, {
+      notFoundAsData: true
+    })
+    if (data && data.error === 'Not found') {
+      return data
+    }
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new RegistryError('Registry package metadata is malformed', {
+        registry: this.registryFor(packageName),
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    return data
+  }
+
+  async getManifest(packageSpec, packument = null) {
+    const spec = npa(packageSpec)
+    const data = packument || (await this.getPackageInfo(spec.name))
+    let version = spec.fetchSpec
+    if (!version || version === '*' || version === 'latest') {
+      version = data['dist-tags'] && data['dist-tags'].latest
+    }
+    if (!data.versions || !data.versions[version]) {
+      throw new Error(`Version ${version} not found for package ${spec.name}`)
+    }
+    return {
+      ...data.versions[version],
+      ...(data.time && data.time[version] ? { _time: data.time[version] } : {})
+    }
+  }
+
+  unavailable(capability) {
+    throw new NotEvaluated(CAPABILITY_MESSAGE[capability], { capability })
+  }
+
+  async getRegistryKeys(packageSpec) {
+    const registry = this.registryFor(packageSpec)
+    const cacheKey = `${registry}|${CAPABILITY.SIGNING_KEYS}`
+    if (this.keyCache.has(cacheKey)) {
+      return this.keyCache.get(cacheKey)
+    }
+    if (this.capabilityCache.get(cacheKey) === false) {
+      return this.unavailable(CAPABILITY.SIGNING_KEYS)
+    }
+    const response = await this.requestJson('-/npm/v1/keys', packageSpec, {
+      capability: CAPABILITY.SIGNING_KEYS
+    })
+    if (!response || !Array.isArray(response.keys)) {
+      throw new RegistryError('Registry signing-key response is malformed', {
+        registry,
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    if (response.keys.length === 0) {
+      this.capabilityCache.set(cacheKey, false)
+      return this.unavailable(CAPABILITY.SIGNING_KEYS)
+    }
+    const keys = response.keys.map((key) => ({
+      ...key,
+      pemkey: `-----BEGIN PUBLIC KEY-----\n${key.key}\n-----END PUBLIC KEY-----`
+    }))
+    this.keyCache.set(cacheKey, keys)
+    return keys
+  }
+
+  async getAttestations(packageSpec, manifest) {
+    const registry = this.registryFor(packageSpec)
+    const cacheKey = `${registry}|${CAPABILITY.ATTESTATIONS}`
+    if (this.capabilityCache.get(cacheKey) === false) {
+      return this.unavailable(CAPABILITY.ATTESTATIONS)
+    }
+    let requestPath
+    try {
+      requestPath = new URL(manifest.dist.attestations.url).pathname.replace(
+        /^\/+/, ''
+      )
+    } catch (error) {
+      throw new RegistryError('Package attestation URL is malformed', {
+        registry,
+        code: 'EREGISTRYPROTOCOL',
+        cause: error
+      })
+    }
+    const response = await this.requestJson(requestPath, packageSpec, {
+      capability: CAPABILITY.ATTESTATIONS
+    })
+    if (!response || !Array.isArray(response.attestations)) {
+      throw new RegistryError('Registry attestation response is malformed', {
+        registry,
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    if (response.attestations.length === 0) {
+      this.capabilityCache.set(cacheKey, false)
+      return this.unavailable(CAPABILITY.ATTESTATIONS)
+    }
+    return response.attestations
+  }
+
+  async getDownloadInfo(packageName) {
+    if (this.registryFor(packageName) !== PUBLIC_REGISTRY) {
+      return this.unavailable(CAPABILITY.DOWNLOAD_COUNTS)
+    }
+    const escapedName = npa(packageName).escapedName
+    const response = await this.requestJson(
+      `https://api.npmjs.org/downloads/point/last-month/${escapedName}`,
+      packageName
+    )
+    if (!response || typeof response.downloads !== 'number') {
+      throw new RegistryError('Registry download response is malformed', {
+        registry: PUBLIC_REGISTRY,
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    return response.downloads
+  }
+}
+
+module.exports = RegistryClient
+```
+
+- [ ] **Step 4: Run tests and commit**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/registryClient.test.js
+npm run lint
+```
+
+Expected: PASS with one HTTP call per cached registry capability and no npmjs call for custom-registry packages.
+
+Commit:
+
+```bash
+git add lib/helpers/registryClient.js __tests__/registryClient.test.js
+git commit -m "feat: centralize authenticated registry requests"
+```
+
+---
+
+### Task 4: Inject the registry context through metadata and CLI startup
+
+**Files:**
+- Modify: `lib/helpers/packageRepoUtils.js:1-43`
+- Modify: `lib/marshall.js:1-55`
+- Modify: `lib/marshalls/baseMarshall.js:8-14`
+- Modify: `lib/marshalls/index.js:20-38,133-145`
+- Modify: `bin/npq.js:8-58`
+- Modify: `bin/npq-hero.js:8-38`
+- Test: `__tests__/packageRepoUtils.test.js`
+- Test: `__tests__/cli.test.js`
+- Test: `__tests__/exitCode.test.js`
+
+**Interfaces:**
+- Consumes: `RegistryConfig.load()`, `new RegistryClient(config)`.
+- Produces: `new Marshall({ registryClient, packageRepoUtils? })`.
+- Produces: every marshall receives `options.registryClient`.
+- Produces: metadata cache key `<normalized-registry>|<package-name>`.
+
+- [ ] **Step 1: Rewrite PackageRepoUtils tests around an injected client**
+
+Replace global-fetch expectations with:
+
+```js
+const registryClient = {
+  registryFor: jest.fn((pkg) =>
+    pkg.startsWith('@company/')
+      ? 'https://artifactory.example.test/api/npm/company/'
+      : 'https://registry.npmjs.org/'
+  ),
+  getPackageInfo: jest.fn().mockResolvedValue(registryPackageOk),
+  getDownloadInfo: jest.fn().mockResolvedValue(1950)
+}
+const packageRepoUtils = new PackageRepoUtils({ registryClient })
+```
+
+Assert two identical requests use one client call, while the same package name after changing its selected registry uses a separate cache entry. Preserve all existing semver, README, license, and GitHub repository tests.
+
+- [ ] **Step 2: Run PackageRepoUtils tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/packageRepoUtils.test.js
+```
+
+Expected: FAIL because PackageRepoUtils still calls global `fetch`.
+
+- [ ] **Step 3: Delegate PackageRepoUtils network access**
+
+Replace its constructor and registry methods with:
+
+```js
+constructor({ registryClient = RegistryClient.public() } = {}) {
+  this.registryClient = registryClient
+  this.pkgInfoCache = {}
+}
+
+getPackageInfo(pkg) {
+  const cacheKey = `${this.registryClient.registryFor(pkg)}|${pkg}`
+  if (this.pkgInfoCache[cacheKey]) {
+    return Promise.resolve(this.pkgInfoCache[cacheKey])
+  }
+  return this.registryClient.getPackageInfo(pkg).then((data) => {
+    this.pkgInfoCache[cacheKey] = data
+    return data
+  })
+}
+
+getDownloadInfo(pkg) {
+  return this.registryClient.getDownloadInfo(pkg)
+}
+```
+
+Import `RegistryClient` at the top. Remove `NPM_REGISTRY`, `NPM_REGISTRY_API`, `registryUrl`, `registryApiUrl`, and direct fetches. Leave non-network helpers unchanged.
+
+- [ ] **Step 4: Pass RegistryClient through Marshall and marshall construction**
+
+In `lib/marshall.js`:
+
+```js
+this.registryClient = options.registryClient || RegistryClient.public()
+this.packageRepoUtils =
+  options.packageRepoUtils ||
+  new PackageRepoUtils({ registryClient: this.registryClient })
+```
+
+Include `registryClient` in `createPackageAuditFunction()` config. In `BaseMarshall`, assign `this.registryClient = options.registryClient`. In `Marshalls.buildMarshallTasks()`, include both `packageRepoUtils` and `registryClient`, and pass the client from `tasks()`.
+
+- [ ] **Step 5: Write CLI startup tests before changing entry points**
+
+Mock:
+
+```js
+jest.mock('../lib/helpers/registryConfig', () => ({
+  load: jest.fn().mockResolvedValue({ requestOptions: {} })
+}))
+jest.mock('../lib/helpers/registryClient', () =>
+  jest.fn().mockImplementation(() => ({ registryFor: jest.fn() }))
+)
+```
+
+For both binaries, assert `RegistryConfig.load` receives the parser's `registryConfigArgs` and `Marshall` receives the constructed `registryClient`. Add a rejected-load case and assert `CliParser.exit` receives the sanitized registry error and no package-manager process is invoked.
+
+- [ ] **Step 6: Load configuration before constructing Marshall**
+
+In each binary, import `RegistryConfig` and `RegistryClient`. Add the first asynchronous stage:
+
+```js
+RegistryConfig.load({ argv: cliArgs.registryConfigArgs })
+  .then((registryConfig) => {
+    const registryClient = new RegistryClient(registryConfig)
+    const marshall = new Marshall({
+      pkgs: cliArgs.packages,
+      registryClient,
+      progressManager: spinner,
+      promiseThrottleHelper
+    })
+    return marshall.process()
+  })
+```
+
+For `bin/npq.js`, retain the existing project-package discovery before constructing `Marshall`; carry `registryClient` through that promise stage. Keep the existing final catch so configuration failures go through `CliParser.exit`.
+
+- [ ] **Step 7: Run focused tests and commit**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/packageRepoUtils.test.js __tests__/cli.test.js __tests__/exitCode.test.js __tests__/marshalls.tasks.test.js
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add lib/helpers/packageRepoUtils.js lib/marshall.js lib/marshalls/baseMarshall.js lib/marshalls/index.js bin/npq.js bin/npq-hero.js __tests__/packageRepoUtils.test.js __tests__/cli.test.js __tests__/exitCode.test.js __tests__/marshalls.tasks.test.js
+git commit -m "feat: inject registry configuration into package audits"
+```
+
+---
+
+### Task 5: Migrate signature and provenance requests
+
+**Files:**
+- Modify: `lib/helpers/npmRegistry.js:1-288`
+- Modify: `lib/marshalls/signatures.marshall.js:1-106`
+- Modify: `lib/marshalls/provenance.marshall.js:1-207`
+- Test: `__tests__/npmRegistry.test.js`
+- Test: `__tests__/marshalls.signatures.test.js`
+- Test: `__tests__/marshalls.provenance.test.js`
+
+**Interfaces:**
+- Consumes: `registryClient.getManifest(spec, packument)`, `getRegistryKeys(spec)`, and `getAttestations(spec, manifest)`.
+- Produces: `NpmRegistry.verifyAttestations(manifest, registryKeys, attestations)`.
+- Preserves: current verification error codes and package-level severity rules.
+
+- [ ] **Step 1: Replace network mocks with injected-client expectations**
+
+In signature tests, construct:
+
+```js
+const registryClient = {
+  getManifest: jest.fn().mockResolvedValue(mockManifest),
+  getRegistryKeys: jest.fn().mockResolvedValue(mockRegistryKeys)
+}
+const marshall = new SignaturesMarshall({
+  packageRepoUtils,
+  registryClient
+})
+```
+
+Assert both methods receive the resolved package spec and the already-fetched packument. Add cases where each method rejects `NotEvaluated` and `RegistryError`; assert those exact instances are rethrown instead of wrapped in `Warning`.
+
+In provenance tests, also mock:
+
+```js
+getAttestations: jest.fn().mockResolvedValue(mockAttestations)
+```
+
+Assert missing `manifest.dist.attestations` keeps the current package warning/regression path without calling `getAttestations`.
+
+- [ ] **Step 2: Run marshall tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/marshalls.signatures.test.js __tests__/marshalls.provenance.test.js
+```
+
+Expected: FAIL because both marshalls still construct hard-coded npmjs clients.
+
+- [ ] **Step 3: Make NpmRegistry verification-only**
+
+Remove `getManifest()`, the constructor registry URL, `npm-package-arg`, and the attestation fetch from `lib/helpers/npmRegistry.js`. Change the attestation signature to:
+
+```js
+async verifyAttestations(manifest, registryKeys, attestations) {
+  if (!manifest.dist || !manifest.dist.attestations) {
+    throw new Error('Package has no attestations to verify')
+  }
+  if (!Array.isArray(attestations)) {
+    throw new Error('Package attestations response is invalid')
+  }
+
+  const bundles = attestations.map(({ predicateType, bundle }) => {
+    const statement = JSON.parse(
+      Buffer.from(bundle.dsseEnvelope.payload, 'base64').toString('utf8')
+    )
+    const keyid = bundle.dsseEnvelope.signatures[0].keyid
+    const signature = bundle.dsseEnvelope.signatures[0].sig
+    return { predicateType, bundle, statement, keyid, signature }
+  })
+```
+
+Keep the remaining subject, integrity, key-expiry, and Sigstore verification logic unchanged. Update `__tests__/npmRegistry.test.js` to pass `mockAttestations` directly and delete manifest/attestation network tests now covered by `registryClient.test.js`.
+
+- [ ] **Step 4: Migrate the signature marshall**
+
+Use one verifier instance and the injected client. Check the manifest for package-level signature absence before requesting the optional key service:
+
+```js
+const verifier = new NpmRegistry()
+const manifest = await this.registryClient.getManifest(
+  `${pkg.packageName}@${resolvedVersion}`,
+  packageInfo
+)
+if (!manifest.dist || !manifest.dist.signatures) {
+  return verifier.verifySignatures(manifest, [])
+}
+const keys = await this.registryClient.getRegistryKeys(pkg.packageName)
+return verifier.verifySignatures(manifest, keys)
+```
+
+Delete `fetchRegistryKeys()`, its module cache, and all hard-coded URLs. At the start of the catch block:
+
+```js
+if (error instanceof NotEvaluated || error instanceof RegistryError) {
+  throw error
+}
+```
+
+Retain expired-key and normal package-warning behavior below it.
+
+- [ ] **Step 5: Migrate the provenance marshall**
+
+After resolving `validationMetadata`, inspect the manifest before requesting optional services. This preserves the existing missing-provenance and provenance-regression behavior even when the registry has no signing-key endpoint:
+
+```js
+const manifest = await this.registryClient.getManifest(
+  `${validationMetadata.name}@${validationMetadata.version}`,
+  validationMetadata.packageInfo
+)
+if (!manifest.dist || !manifest.dist.attestations) {
+  return verifier.verifyAttestations(manifest, [], null)
+}
+const [keys, attestations] = await Promise.all([
+  this.registryClient.getRegistryKeys(validationMetadata.name),
+  this.registryClient.getAttestations(validationMetadata.name, manifest)
+])
+return verifier.verifyAttestations(manifest, keys, attestations)
+```
+
+Delete `fetchRegistryKeys()` and hard-coded URLs. At the start of the catch block, rethrow `NotEvaluated` and `RegistryError` before provenance-regression classification. Preserve malformed-checkpoint suppression and all existing package-level warnings/errors.
+
+- [ ] **Step 6: Run tests and commit**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/npmRegistry.test.js __tests__/marshalls.signatures.test.js __tests__/marshalls.provenance.test.js
+npm run lint
+```
+
+Expected: PASS, and:
+
+```bash
+rg -n "registry\.npmjs\.org" lib/marshalls/signatures.marshall.js lib/marshalls/provenance.marshall.js lib/helpers/npmRegistry.js
+```
+
+Expected: no matches.
+
+Commit:
+
+```bash
+git add lib/helpers/npmRegistry.js lib/marshalls/signatures.marshall.js lib/marshalls/provenance.marshall.js __tests__/npmRegistry.test.js __tests__/marshalls.signatures.test.js __tests__/marshalls.provenance.test.js
+git commit -m "feat: verify signatures and provenance through configured registries"
+```
+
+---
+
+### Task 6: Expose skipped checks without changing install decisions
+
+**Files:**
+- Modify: `bin/npq.js:58-130`
+- Modify: `bin/npq-hero.js:39-102`
+- Test: `__tests__/cli.test.js`
+- Test: `__tests__/exitCode.test.js`
+- Test: `__tests__/marshalls.downloads.test.js`
+- Test: `__tests__/packageManager.test.js`
+
+**Interfaces:**
+- Consumes: `reportResults().countNotEvaluated`.
+- Produces: visible output when skipped checks are the only results.
+- Preserves: prompt/install decisions use only `countErrors` and `countWarnings`.
+
+- [ ] **Step 1: Add failing CLI decision tests**
+
+Mock `reportResults` with:
+
+```js
+{
+  countErrors: 0,
+  countWarnings: 0,
+  countNotEvaluated: 2,
+  resultsForPrettyPrint: 'skipped-rich',
+  resultsForPlainTextPrint: 'skipped-plain',
+  summaryForPrettyPrint: 'summary-rich',
+  summaryForPlainTextPrint: 'summary-plain',
+  useRichFormatting: false
+}
+```
+
+For both binaries assert:
+
+- skipped output is printed;
+- neither prompt nor auto-continue runs;
+- an explicit install still invokes the package manager;
+- audit-only mode exits successfully;
+- a mixed skipped-plus-warning result still follows warning behavior.
+
+Add a download marshall case whose injected helper rejects `NotEvaluated`; through `BaseMarshall.run()`, assert the result contains one skipped entry and no warning/error.
+
+- [ ] **Step 2: Run focused tests and verify they fail**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/cli.test.js __tests__/exitCode.test.js __tests__/marshalls.downloads.test.js
+```
+
+Expected: FAIL because the binaries print only when warnings or errors exist.
+
+- [ ] **Step 3: Separate reportability from findings**
+
+In both binaries replace the current `isErrors` block with:
+
+```js
+const {
+  countErrors,
+  countWarnings,
+  countNotEvaluated = 0,
+  useRichFormatting
+} = results
+const hasFindings = countErrors > 0 || countWarnings > 0
+const hasReportableResults = hasFindings || countNotEvaluated > 0
+
+if (hasReportableResults) {
+  console.log()
+  console.log(
+    hasFindings ? 'Packages with issues found:' : 'Package checks not evaluated:'
+  )
+  if (useRichFormatting) {
+    console.log(results.resultsForPrettyPrint)
+    console.log(results.summaryForPrettyPrint)
+  } else {
+    console.log(results.resultsForPlainTextPrint)
+    console.log(results.summaryForPlainTextPrint)
+  }
+}
+
+return {
+  anyIssues: hasFindings,
+  countErrors,
+  countWarnings,
+  countNotEvaluated
+}
+```
+
+Leave the audit-only exit calculation and prompt branches based only on errors and warnings.
+
+- [ ] **Step 4: Verify registry flags remain forwarded**
+
+Add to `__tests__/packageManager.test.js`:
+
+```js
+process.argv = [
+  'node',
+  'npq',
+  'install',
+  '@company/tool',
+  '--registry=https://artifactory.example.test/api/npm/npm/'
+]
+await packageManager.process('pnpm')
+expect(childProcess.spawn).toHaveBeenCalledWith(
+  'pnpm install @company/tool --registry=https://artifactory.example.test/api/npm/npm/',
+  expect.objectContaining({ stdio: 'inherit', shell: true })
+)
+```
+
+- [ ] **Step 5: Run tests and commit**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/cli.test.js __tests__/exitCode.test.js __tests__/marshalls.downloads.test.js __tests__/packageManager.test.js
+```
+
+Expected: PASS.
+
+Commit:
+
+```bash
+git add bin/npq.js bin/npq-hero.js __tests__/cli.test.js __tests__/exitCode.test.js __tests__/marshalls.downloads.test.js __tests__/packageManager.test.js
+git commit -m "feat: report registry checks that were not evaluated"
+```
+
+---
+
+### Task 7: Prove authenticated Artifactory behavior end to end
+
+**Files:**
+- Create: `__tests__/customRegistry.integration.test.js`
+- Modify: `__tests__/registryConfig.test.js`
+- Modify: `__tests__/registryClient.test.js`
+- Modify: `__tests__/marshalls.tasks.test.js`
+
+**Interfaces:**
+- Exercises: `RegistryConfig -> RegistryClient -> PackageRepoUtils -> Marshall -> marshall result`.
+- Proves: per-scope routing, auth/path isolation, CA/proxy flattening, no npmjs fallback, fatal propagation, and redaction.
+
+- [ ] **Step 1: Add real config-file integration fixtures**
+
+In `__tests__/customRegistry.integration.test.js`, create a temporary project with:
+
+```ini
+registry=https://artifactory.example.test/artifactory/api/npm/npm/
+@company:registry=https://artifactory.example.test/artifactory/api/npm/company/
+//artifactory.example.test/artifactory/api/npm/:_authToken=${ARTIFACTORY_TOKEN}
+strict-ssl=true
+```
+
+Load it with:
+
+```js
+const config = await RegistryConfig.load({
+  argv: [],
+  env: {
+    ...process.env,
+    HOME: home,
+    ARTIFACTORY_TOKEN: 'integration-secret',
+    npm_config_userconfig: userConfig,
+    npm_config_globalconfig: globalConfig
+  },
+  cwd: project
+})
+```
+
+Inject a transport whose `json` implementation records URL/options and returns Artifactory-style packuments, keys, and attestations. Construct `RegistryClient`, `PackageRepoUtils`, and `Marshall` with that client.
+
+Limit the integration run to the registry-dependent marshalls and bypass cryptographic fixture complexity:
+
+```js
+jest.spyOn(Marshalls, 'collectMarshalls').mockResolvedValue([
+  path.join(process.cwd(), 'lib/marshalls/signatures.marshall.js'),
+  path.join(process.cwd(), 'lib/marshalls/provenance.marshall.js'),
+  path.join(process.cwd(), 'lib/marshalls/downloads.marshall.js')
+])
+jest
+  .spyOn(NpmRegistry.prototype, 'verifySignatures')
+  .mockResolvedValue({ _signatures: [{}] })
+jest
+  .spyOn(NpmRegistry.prototype, 'verifyAttestations')
+  .mockResolvedValue({ _attestations: {} })
+```
+
+- [ ] **Step 2: Assert the full success path and privacy boundary**
+
+Audit one unscoped package and one `@company` package. Assert:
+
+```js
+expect(calls.every(({ url }) => !String(url).includes('registry.npmjs.org'))).toBe(true)
+expect(calls.every(({ url }) => !String(url).includes('api.npmjs.org'))).toBe(true)
+expect(calls.some(({ options }) =>
+  options['//artifactory.example.test/artifactory/api/npm/:_authToken'] ===
+  'integration-secret'
+)).toBe(true)
+```
+
+Assert the scoped packument uses the company registry, attestation requests use relative paths under the selected Artifactory base path, and no report/error string contains `integration-secret`.
+
+- [ ] **Step 3: Assert optional and fatal paths**
+
+Add transport variants:
+
+- key endpoint `404`: signatures and provenance become `notEvaluated`, with one capability probe per registry;
+- download check on Artifactory: `notEvaluated` with zero public API calls;
+- packument `401`: `Marshall.process()` rejects `RegistryError` with code `EREGISTRYAUTH`;
+- key endpoint `500`: the audit rejects rather than skipping;
+- malformed key or attestation JSON: the audit rejects `EREGISTRYPROTOCOL`;
+- metadata `404`: existing `not_found` marshall result remains.
+
+- [ ] **Step 4: Cover CA, client certificate, proxy, and redaction**
+
+In `registryConfig.test.js`, create temporary CA, cert, and key PEM files and registry-scoped `certfile`/`keyfile` entries. Set `https-proxy` and `strict-ssl`. Assert `config.requestOptions.ca` contains the loaded CA text, `httpsProxy` and `strictSSL` contain the flattened values, and the registry-scoped `certfile` and `keyfile` entries contain their file paths. `npm-registry-fetch` reads the client certificate and key from those scoped paths only when it authenticates to the matching registry.
+
+In `registryClient.test.js`, make the transport reject with an error message containing a token and a credential-bearing URL. Assert the public `RegistryError.message`, `registry`, and JSON serialization contain neither secret nor URL credentials. Keep raw cause text only in the non-rendered `cause` field and never concatenate it into the public error message.
+
+- [ ] **Step 5: Run integration and full regression tests**
+
+Run:
+
+```bash
+npm test -- --runInBand __tests__/customRegistry.integration.test.js __tests__/registryConfig.test.js __tests__/registryClient.test.js __tests__/marshalls.tasks.test.js
+npm test -- --runInBand
+npm run lint
+```
+
+Expected: all tests and lint pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add __tests__/customRegistry.integration.test.js __tests__/registryConfig.test.js __tests__/registryClient.test.js __tests__/marshalls.tasks.test.js lib/helpers/registryErrors.js
+git commit -m "test: cover authenticated custom registry audits"
+```
+
+---
+
+### Task 8: Document and release custom-registry support
+
+**Files:**
+- Create: `docs/feature/custom-registry.md`
+- Create: `.changeset/bright-tools-audit.md`
+- Modify: `README.md:73-125,127-176,260-263`
+- Modify: `docs/README.md`
+
+**Interfaces:**
+- Documents: standard config, precedence, scoped auth, CA setup, skipped capabilities, failure behavior, and no-fallback guarantee.
+- Produces: a minor release note for package `npq`.
+
+- [ ] **Step 1: Write the user guide**
+
+Create `docs/feature/custom-registry.md` with these tested examples:
+
+```ini
+registry=https://artifactory.example.com/artifactory/api/npm/npm-virtual/
+//artifactory.example.com/artifactory/api/npm/npm-virtual/:_authToken=${ARTIFACTORY_TOKEN}
+```
+
+```ini
+@company:registry=https://artifactory.example.com/artifactory/api/npm/company/
+//artifactory.example.com/artifactory/api/npm/company/:_authToken=${ARTIFACTORY_TOKEN}
+```
+
+```ini
+cafile=/absolute/path/to/company-ca.pem
+strict-ssl=true
+```
+
+State the exact precedence, explain that `--registry` is shared with the installer, list signatures/provenance/downloads as checks that may report `not evaluated`, and state that npq never falls back to npmjs for a package assigned to a custom registry. Warn users to scope auth keys to the registry host/path and never commit tokens.
+
+- [ ] **Step 2: Update README and documentation index**
+
+Add a “Custom registries” subsection under Usage with:
+
+```sh
+npq install @company/tool --registry=https://artifactory.example.com/artifactory/api/npm/npm-virtual/
+```
+
+Link to `docs/feature/custom-registry.md`. Update the marshall documentation for signatures, provenance, and downloads to mention `not evaluated` behavior. Add the feature guide and this plan under the appropriate sections of `docs/README.md`.
+
+- [ ] **Step 3: Add the Changeset**
+
+Create `.changeset/bright-tools-audit.md`:
+
+```markdown
+---
+'npq': minor
+---
+
+Add authenticated default and scoped custom-registry support using standard npm configuration, with explicit reporting when optional registry services cannot be evaluated.
+```
+
+- [ ] **Step 4: Run final verification**
+
+Run:
+
+```bash
+npm test -- --runInBand
+npm run lint
+git diff --check
+rg -n "https?://registry\.npmjs\.org|https?://api\.npmjs\.org" lib
+```
+
+Expected:
+
+- all tests pass;
+- lint passes;
+- `git diff --check` prints nothing;
+- remaining npmjs constants exist only in `registryConfig.js` and `registryClient.js` as explicit public defaults/services, not in marshalls or metadata helpers.
+
+Run a build smoke test:
+
+```bash
+npm run build
+```
+
+Expected: exit code 0 and no generated build artifact is staged.
+
+- [ ] **Step 5: Review scope and commit**
+
+Run:
+
+```bash
+git status --short
+git diff --stat
+```
+
+Expected: only custom-registry implementation, tests, docs, dependency lockfile, and Changeset files are present.
+
+Commit:
+
+```bash
+git add README.md docs/README.md docs/feature/custom-registry.md .changeset/bright-tools-audit.md
+git commit -m "docs: explain custom registry configuration"
+```
+
+---
+
+## Completion Checklist
+
+- [ ] Default npmjs behavior passes all existing tests.
+- [ ] Project, user, global, environment, and CLI precedence are covered.
+- [ ] Default and scoped Artifactory registry routing are covered.
+- [ ] Token, basic auth, proxy, CA, client certificate, and strict-TLS propagation are covered.
+- [ ] Metadata, manifests, keys, and attestations use the selected registry context.
+- [ ] Custom-registry packages trigger no npmjs registry/download requests.
+- [ ] Optional capability absence is visible and non-failing.
+- [ ] Auth, transport, server, and malformed-response failures abort with redacted errors.
+- [ ] Signature and provenance package-level severity behavior remains unchanged.
+- [ ] Both `npq` and `npq-hero` are covered.
+- [ ] README, feature docs, docs index, and Changeset are complete.
+- [ ] `npm test -- --runInBand`, `npm run lint`, `npm run build`, and `git diff --check` pass.

--- a/docs/superpowers/specs/2026-07-11-custom-registry-support-design.md
+++ b/docs/superpowers/specs/2026-07-11-custom-registry-support-design.md
@@ -1,0 +1,294 @@
+# Custom Registry Support Design
+
+## Context
+
+[Issue #429](https://github.com/lirantal/npq/issues/429) reports that npq cannot run in
+an environment where the public npm registry is blocked and package installation uses an
+internal Artifactory npm registry. The package manager honors the user's `.npmrc`, but npq's
+audit phase currently makes independent requests to hard-coded npmjs endpoints.
+
+Registry access is split across `PackageRepoUtils`, the signature marshall, and the
+provenance marshall. Although some helper constructors accept a registry URL, the CLI does
+not load npm configuration or inject it into those helpers. The public npm downloads API is
+also a separate, hard-coded service.
+
+## Goals
+
+- Honor standard npm-compatible configuration for default and scoped registries.
+- Preserve npm's CLI, environment, project, user, and global configuration precedence.
+- Support registry-scoped tokens, basic authentication, proxy settings, custom certificate
+  authorities, client certificates, and strict TLS configuration.
+- Route every package-registry audit request through the registry selected for that package.
+- Never silently fall back to npmjs when a custom registry is configured.
+- Distinguish an unavailable optional registry capability from a failed registry connection.
+- Make unavailable optional checks visible without treating them as package findings.
+- Keep default public-npm behavior compatible with current npq behavior.
+
+## Non-goals
+
+- Native Yarn `.yarnrc.yml` parsing.
+- Artifactory administration APIs or registry-specific analytics integrations.
+- Synthesizing public npm download counts for packages installed through a custom registry.
+- Falling back to another registry when the configured registry is unavailable.
+- Changing existing marshall severities when the data required by a marshall is available.
+
+## Chosen Approach
+
+npq will use a central npm-compatible registry context rather than extending its existing
+`fetch` calls independently or delegating metadata lookups to package-manager subprocesses.
+
+The implementation will use `@npmcli/config` to load and validate standard npm configuration
+and `npm-registry-fetch` for registry selection, authentication, and transport. Versions will
+be selected during implementation that support the repository's Node.js 24 runtime. npq will
+not parse `.npmrc` authentication records itself and will not depend on a globally installed
+npm module at runtime.
+
+This approach centralizes security-sensitive configuration and prevents the metadata,
+signature, and provenance code paths from resolving registries differently.
+
+## Architecture
+
+The dependency flow is:
+
+```text
+CLI entry point
+  -> RegistryConfig
+  -> RegistryClient
+  -> Marshall
+  -> PackageRepoUtils and registry-dependent marshalls
+```
+
+### `RegistryConfig`
+
+`RegistryConfig` loads configuration once per npq process. It receives the current working
+directory, environment, and supported registry-related CLI options. It exposes:
+
+- the effective default registry;
+- package-scope registry mappings;
+- flattened request configuration for `npm-registry-fetch`;
+- the source level of non-secret settings for diagnostics; and
+- sanitized registry descriptions that never contain credentials.
+
+It validates configuration before any audit request. Invalid authentication scoping,
+unreadable referenced files, or invalid TLS configuration stops the audit.
+
+npq supplies the npm configuration definitions and defaults that it consumes through its
+runtime dependencies. It does not shell out to `npm config`, because subprocess output is not
+a safe or complete transport for authentication and connection settings.
+
+### `RegistryClient`
+
+`RegistryClient` is the only component that performs npm-registry HTTP requests. For each
+package, it derives the package scope and selects `@scope:registry` when configured, otherwise
+the default `registry`.
+
+It provides explicit operations for:
+
+- package packuments;
+- resolved-version manifests;
+- registry signing keys;
+- attestation bundles; and
+- public npm download counts when applicable.
+
+It normalizes registry URLs and applies the complete flattened request configuration to
+`npm-registry-fetch`. It also owns per-registry capability state.
+
+### `PackageRepoUtils`
+
+`PackageRepoUtils` remains the higher-level metadata and semver helper. It delegates network
+operations to `RegistryClient`. Package-information cache keys include the normalized registry
+URL and package name, preventing data from a default registry and a scoped registry from
+colliding.
+
+### Marshall injection
+
+Both `npq` and `npq-hero` initialize one registry context and pass it into `Marshall`.
+`Marshall` passes the same client to `PackageRepoUtils` and all registry-dependent marshalls.
+Signature and provenance marshalls no longer construct clients with hard-coded registry URLs.
+
+Registry signing-key and capability caches are keyed by normalized registry URL. A process
+using multiple scoped registries never reuses keys or capability decisions across registries.
+
+## Configuration Semantics
+
+The supported precedence is:
+
+1. Supported npm-compatible CLI settings, including `--registry`, `--userconfig`, and
+   `--globalconfig`.
+2. `npm_config_*` environment variables.
+3. Project `.npmrc`.
+4. User `.npmrc`.
+5. Global `.npmrc`.
+6. npm-compatible defaults supplied by npq.
+
+The CLI parser separates npq-owned flags from registry configuration and package-manager
+arguments. `--registry` affects the audit and remains available to the eventual package-manager
+command. npq does not add `NPQ_REGISTRY` or `--npq-registry`; there is only one registry
+configuration surface.
+
+Registry selection is package-specific. For example, `@company/tool` uses
+`@company:registry` when present, while an unscoped package uses the default registry.
+Credentials remain scoped by registry host and path according to npm rules. They are never
+copied to a different origin.
+
+`NPQ_PKG_MGR` continues to select the installation command only. The registry audit behavior
+does not change based on whether npm, pnpm, or Yarn performs the installation. `.npmrc` is the
+interoperability surface for this feature.
+
+## Request Flow
+
+For each package:
+
+1. `RegistryConfig` resolves the effective registry from the package scope.
+2. `RegistryClient` fetches the package packument using the selected registry and its scoped
+   credentials and connection configuration.
+3. `PackageRepoUtils` caches the packument by registry and package and supplies it to marshalls.
+4. Marshalls that require a manifest, signing keys, or attestations request them through the
+   same client and registry context.
+5. Results are reported as findings, successful checks, or `notEvaluated` checks.
+
+An attestation URL advertised by package metadata is not followed to a different origin.
+The client retains the endpoint path and appends it to the selected registry base URL while
+preserving any Artifactory repository path prefix. This keeps requests inside an Artifactory
+proxy and prevents credential or package-name disclosure to a registry that the user did not
+select.
+
+## Capability Model
+
+The marshall result model gains a non-failing `notEvaluated` collection alongside warnings,
+errors, and data. Each entry identifies the package and gives a stable, concise reason.
+`notEvaluated` entries:
+
+- appear in plain and rich output;
+- do not increment warning or error counts;
+- do not trigger prompts or auto-continue;
+- do not change the process exit status; and
+- are grouped naturally by marshall to avoid repetitive output.
+
+An optional registry service is considered unavailable when its endpoint returns `404`, `405`,
+or `501`, or when a well-formed response explicitly indicates that the capability is absent.
+Empty signing-key capability data is also unavailable. Invalid JSON or a response that violates
+the expected protocol is a registry failure, not an unavailable capability.
+
+Capability results are cached per registry URL. Known-unavailable endpoints are not probed once
+per package.
+
+### Signature and provenance behavior
+
+If signing-key or attestation services are unavailable, the affected marshall reports
+`notEvaluated`. Provenance regression logic is not run without the evidence required to verify
+the target release.
+
+When services are available, current package-level semantics remain unchanged. An unsigned
+package, a package published without provenance, an invalid signature, or a provenance
+regression continues to produce the same severity it produces today.
+
+### Download behavior
+
+The downloads marshall uses `api.npmjs.org` only when the selected registry is the normalized
+public npm registry. For every custom registry, it reports `notEvaluated` without contacting the
+public downloads API. Registry-specific download analytics are out of scope.
+
+## Error Handling
+
+The following failures stop the audit rather than becoming `notEvaluated`:
+
+- authentication or authorization failures, including `401` and `403`;
+- TLS, proxy, certificate, DNS, timeout, and connection failures;
+- registry server failures;
+- malformed or unusable core package metadata;
+- malformed optional-service responses; and
+- invalid npm configuration.
+
+A package metadata `404` retains npq's existing package-not-found result. An optional endpoint
+`404` is interpreted as an unavailable capability only after the core package lookup has
+succeeded.
+
+Errors shown to users include the sanitized registry origin and actionable failure category.
+They never include authorization headers, tokens, passwords, raw certificate contents, or URLs
+containing embedded credentials.
+
+## Security and Privacy Invariants
+
+- Auditing a package assigned to a custom registry causes zero package-registry or download
+  requests to npmjs. Packages explicitly assigned to npmjs may still use npmjs in the same run.
+- Authentication material is sent only to the matching registry host and path.
+- Registry configuration and errors are redacted before logging or reporting.
+- Scoped registries have isolated metadata, signing-key, and capability caches.
+- No fallback registry is attempted after a network, authentication, or capability failure.
+- Optional-service absence is visible and cannot be misreported as a successful security check.
+
+These invariants apply to both `npq` and `npq-hero`.
+
+## Compatibility
+
+With no custom registry configuration, npq continues to use
+`https://registry.npmjs.org/`, including the public npm download-count service. Existing
+marshall-disable environment variables, finding severities, prompts, and default registry
+behavior remain unchanged.
+
+The change adds runtime dependencies and updates the lockfile, but does not change the minimum
+Node.js or npm versions. Native Yarn configuration and non-npm registry protocols remain outside
+the compatibility contract.
+
+## Testing Strategy
+
+Tests use mocked configuration files and HTTP responses; CI does not require a live Artifactory
+instance or real credentials.
+
+### Configuration tests
+
+- CLI, environment, project, user, and global precedence.
+- Default and multiple scoped registry selection.
+- Environment expansion in `.npmrc`.
+- Token and basic authentication scoping.
+- Proxy, CA, client certificate, and strict-TLS propagation.
+- Invalid auth scoping and unreadable configuration failures.
+
+### Client tests
+
+- Packument, manifest, key, attestation, and public-download endpoint construction.
+- Scoped registry and credential selection per package.
+- Cache isolation by registry and package.
+- Attestation paths rebased to the selected registry.
+- No npmjs request when a custom registry is selected.
+- Capability caching and `notEvaluated` classification.
+- Fatal classification for auth, TLS, network, protocol, and server errors.
+- Redaction of every supported credential form from output and errors.
+
+### Marshall and CLI tests
+
+- Signature, provenance, and downloads behavior for supported and unsupported services.
+- Existing public npm behavior and finding severities.
+- `notEvaluated` rendering in plain and rich output.
+- Warning/error counts, prompts, auto-continue, and exit status unaffected by skipped checks.
+- End-to-end configuration and `--registry` forwarding for `npq` and `npq-hero`.
+
+## Documentation and Release
+
+Implementation will add a user-facing custom-registry document with examples for:
+
+- a default Artifactory registry;
+- a scoped internal registry;
+- registry-scoped token authentication; and
+- a custom certificate authority.
+
+The README and documentation index will link to that guide and describe `notEvaluated` checks
+and the no-fallback guarantee. The change requires a Changeset because it adds user-visible
+package behavior.
+
+## Acceptance Criteria
+
+The feature is complete when:
+
+1. A package available only through an authenticated Artifactory npm registry can be audited by
+   both `npq` and `npq-hero` using standard `.npmrc` configuration.
+2. Default and scoped registries resolve with standard npm precedence.
+3. No npmjs package-registry or download request occurs for a package assigned to a custom
+   registry.
+4. Missing optional services appear as `notEvaluated` without affecting findings, prompts, or
+   exit status.
+5. Registry configuration, authentication, transport, and metadata failures stop the audit with
+   redacted, actionable errors.
+6. Existing default npmjs behavior and marshall severities remain covered and unchanged.
+7. Tests, lint, documentation, and a Changeset satisfy the repository contribution rules.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -20,6 +20,12 @@ const INSTALL_SUBCOMMANDS = new Set([
 ])
 
 class CliParser {
+  static registryConfigArgs(values = {}) {
+    return ['registry', 'userconfig', 'globalconfig'].flatMap((key) =>
+      values[key] ? [`--${key}=${values[key]}`] : []
+    )
+  }
+
   static isInstallSubcommand(token) {
     return INSTALL_SUBCOMMANDS.has(token)
   }
@@ -67,6 +73,9 @@ class CliParser {
       packageManager: { type: 'string' },
       pkgMgr: { type: 'string' },
       'disable-auto-continue': { type: 'boolean' },
+      registry: { type: 'string' },
+      userconfig: { type: 'string' },
+      globalconfig: { type: 'string' },
       help: { type: 'boolean', short: 'h' },
       version: { type: 'boolean', short: 'v' }
     }
@@ -95,6 +104,9 @@ Options:
       --packageManager        Package Manager to use (default: npm)
       --pkgMgr                Alias for packageManager
       --disable-auto-continue Disable auto-continue countdown, always prompt
+      --registry              npm registry used for audit and install
+      --userconfig            Path to the user npm configuration file
+      --globalconfig          Path to the global npm configuration file
   -h, --help                  Show help
   -v, --version               Show version
 
@@ -127,6 +139,7 @@ curated by Liran Tal at https://github.com/lirantal/npq`)
       plain: values.plain || false,
       disableAutoContinue:
         values['disable-auto-continue'] || process.env.NPQ_DISABLE_AUTO_CONTINUE === 'true',
+      registryConfigArgs: this.registryConfigArgs(values),
       installSubcommandExplicit
     }
   }
@@ -140,17 +153,21 @@ curated by Liran Tal at https://github.com/lirantal/npq`)
           type: 'string',
           short: 'i',
           default: 'install'
-        }
+        },
+        registry: { type: 'string' },
+        userconfig: { type: 'string' },
+        globalconfig: { type: 'string' }
       }
     }
 
-    const { positionals } = parseArgs(config)
+    const { values, positionals } = parseArgs(config)
 
     const earlyExitNoInstall = true
     const normalizedPackages = this._extractPackagesFromPositionals(positionals, earlyExitNoInstall)
 
     return {
-      packages: normalizedPackages
+      packages: normalizedPackages,
+      registryConfigArgs: this.registryConfigArgs(values)
     }
   }
 }

--- a/lib/helpers/notEvaluated.js
+++ b/lib/helpers/notEvaluated.js
@@ -1,0 +1,11 @@
+'use strict'
+
+class NotEvaluated extends Error {
+  constructor(message, { capability = null } = {}) {
+    super(message)
+    this.name = 'NotEvaluated'
+    this.capability = capability
+  }
+}
+
+module.exports = NotEvaluated

--- a/lib/helpers/npmRegistry.js
+++ b/lib/helpers/npmRegistry.js
@@ -13,57 +13,6 @@ const MISSING_TIME_CUTOFF = '2015-01-01T00:00:00.000Z'
  * This replaces pacote functionality for npq specific needs
  */
 class NpmRegistry {
-  constructor(opts = {}) {
-    this.opts = opts
-    this.registry = opts.registry || 'https://registry.npmjs.org'
-  }
-
-  /**
-   * Fetch package manifest from npm registry
-   * @param {string} packageSpec - Package name and version (e.g., 'express@4.18.2')
-   * @param {Object} options - Additional options
-   * @returns {Promise<Object>} Package manifest
-   */
-  async getManifest(packageSpec, options = {}) {
-    const spec = npa(packageSpec)
-    const escapedName = spec.escapedName
-    const packumentUrl = `${this.registry}/${escapedName}`
-
-    // Fetch packument (package metadata)
-    const response = await fetch(packumentUrl, {
-      headers: {
-        accept: 'application/json',
-        'user-agent': 'npq-npm-registry-client',
-        ...(options.headers || {})
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch package manifest: ${response.status} ${response.statusText}`)
-    }
-
-    const packument = await response.json()
-
-    // Pick the specific version
-    let version = spec.fetchSpec
-    if (version === 'latest' || !version || version === '*') {
-      version = packument['dist-tags']?.latest
-    }
-
-    if (!packument.versions || !packument.versions[version]) {
-      throw new Error(`Version ${version} not found for package ${spec.name}`)
-    }
-
-    const manifest = packument.versions[version]
-
-    // Add timing information if available
-    if (packument.time && packument.time[version]) {
-      manifest._time = packument.time[version]
-    }
-
-    return manifest
-  }
-
   /**
    * Verify package signatures using npm registry public keys
    * @param {Object} manifest - Package manifest
@@ -140,26 +89,14 @@ class NpmRegistry {
    * @param {Array} registryKeys - Public keys from npm registry
    * @returns {Promise<Object>} Verified manifest with _attestations
    */
-  async verifyAttestations(manifest, registryKeys) {
+  async verifyAttestations(manifest, registryKeys, attestations) {
     if (!manifest.dist || !manifest.dist.attestations) {
       throw new Error('Package has no attestations to verify')
     }
 
-    const attestationsPath = new URL(manifest.dist.attestations.url).pathname
-    const attestationsUrl = this.registry + attestationsPath
-
-    const response = await fetch(attestationsUrl, {
-      headers: {
-        accept: 'application/json',
-        'user-agent': 'npq-npm-registry-client'
-      }
-    })
-
-    if (!response.ok) {
-      throw new Error(`Failed to fetch attestations: ${response.status} ${response.statusText}`)
+    if (!Array.isArray(attestations)) {
+      throw new Error('Package attestations response is invalid')
     }
-
-    const { attestations } = await response.json()
 
     const bundles = attestations.map(({ predicateType, bundle }) => {
       const statement = JSON.parse(

--- a/lib/helpers/packageRepoUtils.js
+++ b/lib/helpers/packageRepoUtils.js
@@ -9,10 +9,6 @@ class PackageRepoUtils {
     this.pkgInfoCache = {}
   }
 
-  formatPackageForUrl(pkg) {
-    return pkg.replace(/\//g, '%2F')
-  }
-
   getPackageInfo(pkg) {
     const cacheKey = `${this.registryClient.registryFor(pkg)}|${pkg}`
     if (this.pkgInfoCache[cacheKey]) {

--- a/lib/helpers/packageRepoUtils.js
+++ b/lib/helpers/packageRepoUtils.js
@@ -1,13 +1,11 @@
 'use strict'
 
 const semver = require('semver')
-const NPM_REGISTRY = 'http://registry.npmjs.org'
-const NPM_REGISTRY_API = 'https://api.npmjs.org'
+const RegistryClient = require('./registryClient')
 
 class PackageRepoUtils {
-  constructor(options = {}) {
-    this.registryUrl = options.registryUrl ? options.registryUrl : NPM_REGISTRY
-    this.registryApiUrl = options.registryApiUrl ? options.registryApiUrl : NPM_REGISTRY_API
+  constructor({ registryClient = RegistryClient.public() } = {}) {
+    this.registryClient = registryClient
     this.pkgInfoCache = {}
   }
 
@@ -16,16 +14,14 @@ class PackageRepoUtils {
   }
 
   getPackageInfo(pkg) {
-    if (this.pkgInfoCache[pkg]) {
-      return Promise.resolve(this.pkgInfoCache[pkg])
-    } else {
-      return fetch(`${this.registryUrl}/${this.formatPackageForUrl(pkg)}`)
-        .then((response) => response.json())
-        .then((data) => {
-          this.pkgInfoCache[pkg] = data
-          return data
-        })
+    const cacheKey = `${this.registryClient.registryFor(pkg)}|${pkg}`
+    if (this.pkgInfoCache[cacheKey]) {
+      return Promise.resolve(this.pkgInfoCache[cacheKey])
     }
+    return this.registryClient.getPackageInfo(pkg).then((data) => {
+      this.pkgInfoCache[cacheKey] = data
+      return data
+    })
   }
 
   getLatestVersion(pkg) {
@@ -35,9 +31,7 @@ class PackageRepoUtils {
   }
 
   getDownloadInfo(pkg) {
-    return fetch(`${this.registryApiUrl}/downloads/point/last-month/${pkg}`)
-      .then((response) => response.json())
-      .then(({ downloads }) => downloads)
+    return this.registryClient.getDownloadInfo(pkg)
   }
 
   getReadmeInfo(pkg) {

--- a/lib/helpers/registryClient.js
+++ b/lib/helpers/registryClient.js
@@ -1,0 +1,202 @@
+'use strict'
+
+const npa = require('npm-package-arg')
+const npmFetch = require('npm-registry-fetch')
+const NotEvaluated = require('./notEvaluated')
+const RegistryConfig = require('./registryConfig')
+const { RegistryError } = require('./registryErrors')
+
+const PUBLIC_REGISTRY = 'https://registry.npmjs.org/'
+const OPTIONAL_STATUS = new Set([404, 405, 501])
+const CAPABILITY = Object.freeze({
+  SIGNING_KEYS: 'signing-keys',
+  ATTESTATIONS: 'attestations',
+  DOWNLOAD_COUNTS: 'download-counts'
+})
+const CAPABILITY_MESSAGE = Object.freeze({
+  [CAPABILITY.SIGNING_KEYS]: 'configured registry does not expose signing keys',
+  [CAPABILITY.ATTESTATIONS]: 'configured registry does not expose attestations',
+  [CAPABILITY.DOWNLOAD_COUNTS]:
+    'download counts are available only for the public npm registry'
+})
+
+class RegistryClient {
+  constructor(registryConfig, { fetcher = npmFetch } = {}) {
+    this.registryConfig = registryConfig
+    this.fetcher = fetcher
+    this.keyCache = new Map()
+    this.capabilityCache = new Map()
+  }
+
+  static public() {
+    return new RegistryClient(RegistryConfig.defaults())
+  }
+
+  registryFor(packageSpec) {
+    return this.registryConfig.registryFor(packageSpec)
+  }
+
+  requestOptions(packageSpec) {
+    return {
+      ...this.registryConfig.requestOptions,
+      spec: packageSpec,
+      headers: {
+        accept: 'application/json',
+        'user-agent': 'npq-npm-registry-client'
+      }
+    }
+  }
+
+  async requestJson(
+    requestPath,
+    packageSpec,
+    { capability = null, notFoundAsData = false } = {}
+  ) {
+    const registry = this.registryFor(packageSpec)
+    try {
+      return await this.fetcher.json(requestPath, this.requestOptions(packageSpec))
+    } catch (error) {
+      const statusCode = error.statusCode || error.status || null
+      if (notFoundAsData && statusCode === 404) {
+        return { error: 'Not found' }
+      }
+      if (capability && OPTIONAL_STATUS.has(statusCode)) {
+        this.capabilityCache.set(`${registry}|${capability}`, false)
+        throw new NotEvaluated(CAPABILITY_MESSAGE[capability], { capability })
+      }
+      const code =
+        statusCode === 401 || statusCode === 403
+          ? 'EREGISTRYAUTH'
+          : statusCode
+            ? 'EREGISTRYHTTP'
+            : 'EREGISTRYNETWORK'
+      throw new RegistryError(
+        statusCode === 401 || statusCode === 403
+          ? 'Registry authentication or authorization failed'
+          : statusCode
+            ? `Registry request failed with HTTP ${statusCode}`
+            : 'Registry network request failed',
+        { registry, code, statusCode, cause: error }
+      )
+    }
+  }
+
+  async getPackageInfo(packageName) {
+    const spec = npa(packageName)
+    const data = await this.requestJson(spec.escapedName, packageName, {
+      notFoundAsData: true
+    })
+    if (data && data.error === 'Not found') {
+      return data
+    }
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      throw new RegistryError('Registry package metadata is malformed', {
+        registry: this.registryFor(packageName),
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    return data
+  }
+
+  async getManifest(packageSpec, packument = null) {
+    const spec = npa(packageSpec)
+    const data = packument || (await this.getPackageInfo(spec.name))
+    let version = spec.fetchSpec
+    if (!version || version === '*' || version === 'latest') {
+      version = data['dist-tags'] && data['dist-tags'].latest
+    }
+    if (!data.versions || !data.versions[version]) {
+      throw new Error(`Version ${version} not found for package ${spec.name}`)
+    }
+    return {
+      ...data.versions[version],
+      ...(data.time && data.time[version] ? { _time: data.time[version] } : {})
+    }
+  }
+
+  unavailable(capability) {
+    throw new NotEvaluated(CAPABILITY_MESSAGE[capability], { capability })
+  }
+
+  async getRegistryKeys(packageSpec) {
+    const registry = this.registryFor(packageSpec)
+    const cacheKey = `${registry}|${CAPABILITY.SIGNING_KEYS}`
+    if (this.keyCache.has(cacheKey)) {
+      return this.keyCache.get(cacheKey)
+    }
+    if (this.capabilityCache.get(cacheKey) === false) {
+      return this.unavailable(CAPABILITY.SIGNING_KEYS)
+    }
+    const response = await this.requestJson('-/npm/v1/keys', packageSpec, {
+      capability: CAPABILITY.SIGNING_KEYS
+    })
+    if (!response || !Array.isArray(response.keys)) {
+      throw new RegistryError('Registry signing-key response is malformed', {
+        registry,
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    if (response.keys.length === 0) {
+      this.capabilityCache.set(cacheKey, false)
+      return this.unavailable(CAPABILITY.SIGNING_KEYS)
+    }
+    const keys = response.keys.map((key) => ({
+      ...key,
+      pemkey: `-----BEGIN PUBLIC KEY-----\n${key.key}\n-----END PUBLIC KEY-----`
+    }))
+    this.keyCache.set(cacheKey, keys)
+    return keys
+  }
+
+  async getAttestations(packageSpec, manifest) {
+    const registry = this.registryFor(packageSpec)
+    const cacheKey = `${registry}|${CAPABILITY.ATTESTATIONS}`
+    if (this.capabilityCache.get(cacheKey) === false) {
+      return this.unavailable(CAPABILITY.ATTESTATIONS)
+    }
+    let requestPath
+    try {
+      requestPath = new URL(manifest.dist.attestations.url).pathname.replace(/^\/+/, '')
+    } catch (error) {
+      throw new RegistryError('Package attestation URL is malformed', {
+        registry,
+        code: 'EREGISTRYPROTOCOL',
+        cause: error
+      })
+    }
+    const response = await this.requestJson(requestPath, packageSpec, {
+      capability: CAPABILITY.ATTESTATIONS
+    })
+    if (!response || !Array.isArray(response.attestations)) {
+      throw new RegistryError('Registry attestation response is malformed', {
+        registry,
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    if (response.attestations.length === 0) {
+      this.capabilityCache.set(cacheKey, false)
+      return this.unavailable(CAPABILITY.ATTESTATIONS)
+    }
+    return response.attestations
+  }
+
+  async getDownloadInfo(packageName) {
+    if (this.registryFor(packageName) !== PUBLIC_REGISTRY) {
+      return this.unavailable(CAPABILITY.DOWNLOAD_COUNTS)
+    }
+    const escapedName = npa(packageName).escapedName
+    const response = await this.requestJson(
+      `https://api.npmjs.org/downloads/point/last-month/${escapedName}`,
+      packageName
+    )
+    if (!response || typeof response.downloads !== 'number') {
+      throw new RegistryError('Registry download response is malformed', {
+        registry: PUBLIC_REGISTRY,
+        code: 'EREGISTRYPROTOCOL'
+      })
+    }
+    return response.downloads
+  }
+}
+
+module.exports = RegistryClient

--- a/lib/helpers/registryClient.js
+++ b/lib/helpers/registryClient.js
@@ -156,7 +156,11 @@ class RegistryClient {
     }
     let requestPath
     try {
-      requestPath = new URL(manifest.dist.attestations.url).pathname.replace(/^\/+/, '')
+      const advertisedPath = new URL(manifest.dist.attestations.url).pathname
+      const registryPath = new URL(registry).pathname
+      requestPath = advertisedPath.startsWith(registryPath)
+        ? advertisedPath.slice(registryPath.length)
+        : advertisedPath.replace(/^\/+/, '')
     } catch (error) {
       throw new RegistryError('Package attestation URL is malformed', {
         registry,

--- a/lib/helpers/registryConfig.js
+++ b/lib/helpers/registryConfig.js
@@ -1,0 +1,77 @@
+'use strict'
+
+const path = require('node:path')
+const Config = require('@npmcli/config')
+const npmFetch = require('npm-registry-fetch')
+const {
+  definitions,
+  flatten,
+  nerfDarts,
+  shorthands
+} = require('@npmcli/config/lib/definitions')
+const { RegistryError, sanitizeRegistryUrl } = require('./registryErrors')
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/'
+
+function normalizeRegistry(value) {
+  const url = new URL(value || DEFAULT_REGISTRY)
+  if (!url.pathname.endsWith('/')) {
+    url.pathname += '/'
+  }
+  return url.toString()
+}
+
+class RegistryConfig {
+  constructor(requestOptions) {
+    this.requestOptions = Object.freeze({
+      ...requestOptions,
+      registry: normalizeRegistry(requestOptions.registry)
+    })
+  }
+
+  static defaults() {
+    return new RegistryConfig({ registry: DEFAULT_REGISTRY })
+  }
+
+  static async load({ argv = [], env = process.env, cwd = process.cwd() } = {}) {
+    try {
+      const registryArg = argv.find((arg) => arg.startsWith('--registry='))
+      if (registryArg) {
+        normalizeRegistry(registryArg.slice('--registry='.length))
+      }
+
+      const config = new Config({
+        npmPath: path.resolve(__dirname, '..'),
+        definitions,
+        shorthands,
+        flatten,
+        nerfDarts,
+        argv: ['node', 'npq', ...argv],
+        env,
+        cwd,
+        warn: false
+      })
+      await config.load()
+      config.validate()
+      return new RegistryConfig(config.flat)
+    } catch (error) {
+      const code =
+        error.code === 'ERR_INVALID_AUTH' ? 'EREGISTRYCONFIGAUTH' : 'EREGISTRYCONFIG'
+      const message =
+        error.code === 'ERR_INVALID_AUTH'
+          ? 'Invalid npm registry authentication configuration'
+          : `Unable to load npm registry configuration: ${error.code || error.name}`
+      throw new RegistryError(message, { code, cause: error })
+    }
+  }
+
+  registryFor(packageSpec) {
+    return normalizeRegistry(npmFetch.pickRegistry(packageSpec, this.requestOptions))
+  }
+
+  describeRegistry(packageSpec) {
+    return sanitizeRegistryUrl(this.registryFor(packageSpec))
+  }
+}
+
+module.exports = RegistryConfig

--- a/lib/helpers/registryConfig.js
+++ b/lib/helpers/registryConfig.js
@@ -52,7 +52,9 @@ class RegistryConfig {
         warn: false
       })
       await config.load()
-      config.validate()
+      if (!config.validate()) {
+        throw new Error('Invalid npm configuration')
+      }
       return new RegistryConfig(config.flat)
     } catch (error) {
       const code =

--- a/lib/helpers/registryErrors.js
+++ b/lib/helpers/registryErrors.js
@@ -1,0 +1,32 @@
+'use strict'
+
+function sanitizeRegistryUrl(value) {
+  try {
+    const url = new URL(value)
+    url.username = ''
+    url.password = ''
+    url.search = ''
+    url.hash = ''
+    return url.toString()
+  } catch {
+    return 'configured registry'
+  }
+}
+
+class RegistryError extends Error {
+  constructor(
+    message,
+    { registry = null, code = 'EREGISTRY', statusCode = null, cause = null } = {}
+  ) {
+    const sanitizedRegistry = registry ? sanitizeRegistryUrl(registry) : null
+    super(sanitizedRegistry ? `${message} (${sanitizedRegistry})` : message, {
+      cause: cause || undefined
+    })
+    this.name = 'RegistryError'
+    this.code = code
+    this.statusCode = statusCode
+    this.registry = sanitizedRegistry
+  }
+}
+
+module.exports = { RegistryError, sanitizeRegistryUrl }

--- a/lib/helpers/reportResults.js
+++ b/lib/helpers/reportResults.js
@@ -108,6 +108,7 @@ function reportResults(marshallResults, { plain = false } = {}) {
 
   let countErrors = 0
   let countWarnings = 0
+  let countNotEvaluated = 0
   let countPackages = results.length
 
   results.forEach((result, index) => {
@@ -219,11 +220,33 @@ function reportResults(marshallResults, { plain = false } = {}) {
       })
     }
 
+    if (result.notEvaluated && result.notEvaluated.length > 0) {
+      result.notEvaluated.forEach((entryArray) => {
+        countNotEvaluated += entryArray.length
+        entryArray.forEach((entry) => {
+          const topicRich = styleText(
+            ['cyan'],
+            entry.categoryFriendlyName.padEnd(maxTextLength, ' ')
+          )
+          const iconRich = styleText(['cyan'], '○')
+          const wrappedMessage = wrapTextWithIndent(
+            entry.message,
+            maxMessageWidth,
+            indentString
+          )
+          resultsForPrettyPrint +=
+            `\n ${prefixRich} ${iconRich} ${topicRich} ${separatorRich} ${wrappedMessage} `
+          resultsForPlainTextPrint +=
+            `\n  NOT EVALUATED: ${entry.categoryFriendlyName} - ${entry.message}`
+        })
+      })
+    }
+
     // Close rich formatting box
     resultsForPrettyPrint += `\n ${styleText(['dim'], '└─')}`
   })
 
-  const maxTextLength = 'Total packages:'.length
+  const maxTextLength = 'Total not evaluated:'.length
 
   // Rich formatting summary
   summaryForPrettyPrint += `\n\n${styleText(['bold'], 'Summary:')}\n`
@@ -239,6 +262,10 @@ function reportResults(marshallResults, { plain = false } = {}) {
     ['yellow', 'bold'],
     String(countWarnings)
   )}`
+  summaryForPrettyPrint += `\n - ${'Total not evaluated:'.padEnd(maxTextLength, ' ')} ${styleText(
+    ['cyan'],
+    String(countNotEvaluated)
+  )}`
   summaryForPrettyPrint += `\n`
 
   // Plain text summary
@@ -246,11 +273,13 @@ function reportResults(marshallResults, { plain = false } = {}) {
   summaryForPlainTextPrint += `\n - Total packages: ${countPackages}`
   summaryForPlainTextPrint += `\n - Total errors: ${countErrors}`
   summaryForPlainTextPrint += `\n - Total warnings: ${countWarnings}`
+  summaryForPlainTextPrint += `\n - Total not evaluated: ${countNotEvaluated}`
   summaryForPlainTextPrint += `\n`
 
   return {
     countErrors,
     countWarnings,
+    countNotEvaluated,
     resultsForPrettyPrint,
     resultsForJSON,
     resultsForPlainTextPrint,
@@ -267,7 +296,8 @@ function marshallResultsToIssuesPerPackage(results) {
     const issues = {
       pkg,
       errors: [],
-      warnings: []
+      warnings: [],
+      notEvaluated: []
     }
     for (const marshall of allMarshallResultsList) {
       for (const value of Object.values(marshall)) {
@@ -294,9 +324,22 @@ function marshallResultsToIssuesPerPackage(results) {
 
           issues.warnings.push(marshallWarnings)
         }
+        if (value.notEvaluated && value.notEvaluated.length > 0) {
+          const skippedChecks = value.notEvaluated.map((entry) => ({
+            marshall: value.marshall,
+            categoryId: value.categoryId,
+            categoryFriendlyName: marshallCategories[value.categoryId].title,
+            ...entry
+          }))
+          issues.notEvaluated.push(skippedChecks)
+        }
       }
     }
-    if (issues.errors.length > 0 || issues.warnings.length > 0) {
+    if (
+      issues.errors.length > 0 ||
+      issues.warnings.length > 0 ||
+      issues.notEvaluated.length > 0
+    ) {
       issuesPerPackage.push(issues)
     }
   }

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -3,12 +3,16 @@
 // const util = require('node:util')
 const Marshalls = require('./marshalls')
 const PackageRepoUtils = require('./helpers/packageRepoUtils')
+const RegistryClient = require('./helpers/registryClient')
 // const { marshallCategories } = require('./marshalls/constants')
 
 class Marshall {
   constructor(options = {}) {
     this.pkgs = options ? options.pkgs : null
-    this.packageRepoUtils = new PackageRepoUtils()
+    this.registryClient = options.registryClient || RegistryClient.public()
+    this.packageRepoUtils =
+      options.packageRepoUtils ||
+      new PackageRepoUtils({ registryClient: this.registryClient })
     this.progressManager = options.progressManager || null
     this.promiseThrottleHelper = options.promiseThrottleHelper || null
   }
@@ -56,7 +60,8 @@ class Marshall {
     const allPackages = Array.isArray(pkg) ? pkg : [pkg]
     const config = {
       pkgs: this.createPackageVersionMaps(allPackages),
-      packageRepoUtils: packageRepoUtils
+      packageRepoUtils: packageRepoUtils,
+      registryClient: this.registryClient
     }
     return Marshalls.tasks(config, this.progressManager)
   }

--- a/lib/marshall.js
+++ b/lib/marshall.js
@@ -8,8 +8,12 @@ const RegistryClient = require('./helpers/registryClient')
 
 class Marshall {
   constructor(options = {}) {
-    this.pkgs = options ? options.pkgs : null
-    this.registryClient = options.registryClient || RegistryClient.public()
+    options = options || {}
+    this.pkgs = options.pkgs || null
+    this.registryClient =
+      options.registryClient ||
+      options.packageRepoUtils?.registryClient ||
+      RegistryClient.public()
     this.packageRepoUtils =
       options.packageRepoUtils ||
       new PackageRepoUtils({ registryClient: this.registryClient })

--- a/lib/marshalls/baseMarshall.js
+++ b/lib/marshalls/baseMarshall.js
@@ -2,6 +2,8 @@
 
 const semver = require('semver')
 const util = require('node:util')
+const NotEvaluated = require('../helpers/notEvaluated')
+const { RegistryError } = require('../helpers/registryErrors')
 const Warning = require('../helpers/warning')
 const { marshallCategories } = require('./constants')
 
@@ -19,6 +21,7 @@ class BaseMarshall {
       status: null,
       errors: [],
       warnings: [],
+      notEvaluated: [],
       data: {},
       marshall: this.name,
       categoryId: this.categoryId
@@ -42,13 +45,22 @@ class BaseMarshall {
         return data
       })
       .catch((err) => {
-        this.setMessage(
-          {
-            pkg: pkg.packageString,
-            message: err.message
-          },
-          Boolean(err instanceof Warning)
-        )
+        if (err instanceof RegistryError) {
+          throw err
+        }
+
+        const message = {
+          pkg: pkg.packageString,
+          message: err.message
+        }
+
+        if (err instanceof NotEvaluated) {
+          this.setNotEvaluated(message)
+          return undefined
+        }
+
+        this.setMessage(message, Boolean(err instanceof Warning))
+        return undefined
       })
   }
 
@@ -64,6 +76,13 @@ class BaseMarshall {
       : this.ctx.marshalls[this.name].errors
 
     messages.push({
+      pkg: msg.pkg,
+      message: msg.message
+    })
+  }
+
+  setNotEvaluated(msg) {
+    this.ctx.marshalls[this.name].notEvaluated.push({
       pkg: msg.pkg,
       message: msg.message
     })

--- a/lib/marshalls/baseMarshall.js
+++ b/lib/marshalls/baseMarshall.js
@@ -11,6 +11,7 @@ class BaseMarshall {
   constructor(options) {
     this.debug = util.debuglog('npq')
     this.packageRepoUtils = options.packageRepoUtils
+    this.registryClient = options.registryClient
     this.categoryId = marshallCategories.PackageHealth.id
   }
 

--- a/lib/marshalls/index.js
+++ b/lib/marshalls/index.js
@@ -21,7 +21,8 @@ class Marshalls {
     }
 
     const config = {
-      packageRepoUtils: options.packageRepoUtils
+      packageRepoUtils: options.packageRepoUtils,
+      registryClient: options.registryClient
     }
 
     const marshallTasks = marshalls.reduce((prev, curr) => {
@@ -121,7 +122,8 @@ class Marshalls {
     const packagesToProcess = options.pkgs
     if (packagesToProcess.length > 0) {
       const marshallTasks = await Marshalls.buildMarshallTasks(marshalls, {
-        packageRepoUtils: options.packageRepoUtils
+        packageRepoUtils: options.packageRepoUtils,
+        registryClient: options.registryClient
       })
 
       for (const marshall of marshallTasks) {

--- a/lib/marshalls/index.js
+++ b/lib/marshalls/index.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs')
 const path = require('node:path')
+const { RegistryError } = require('../helpers/registryErrors')
 
 class Marshalls {
   static async collectMarshalls() {
@@ -96,6 +97,7 @@ class Marshalls {
               status: null,
               errors: [{ pkg: options.pkgs[index].packageName, message: 'Package not found' }],
               warnings: [],
+              notEvaluated: [],
               data: {},
               categoryId: 'PackageHealth'
             }
@@ -130,6 +132,9 @@ class Marshalls {
           })
           marshallResults.push(res.marshalls)
         } catch (error) {
+          if (error instanceof RegistryError) {
+            throw error
+          }
           console.error(`Error running task ${marshall.title}:`, error)
         }
       }

--- a/lib/marshalls/provenance.marshall.js
+++ b/lib/marshalls/provenance.marshall.js
@@ -109,7 +109,7 @@ class Marshall extends BaseMarshall {
       }
 
       const manifest = await this.registryClient.getManifest(
-        `${validationMetadata.name}@${validationMetadata.version}`,
+        `${pkg.packageName}@${validationMetadata.version}`,
         packageInfo
       )
       let metadata
@@ -117,8 +117,8 @@ class Marshall extends BaseMarshall {
         metadata = await verifier.verifyAttestations(manifest, [], null)
       } else {
         const [keys, attestations] = await Promise.all([
-          this.registryClient.getRegistryKeys(validationMetadata.name),
-          this.registryClient.getAttestations(validationMetadata.name, manifest)
+          this.registryClient.getRegistryKeys(pkg.packageName),
+          this.registryClient.getAttestations(pkg.packageName, manifest)
         ])
         metadata = await verifier.verifyAttestations(manifest, keys, attestations)
       }

--- a/lib/marshalls/provenance.marshall.js
+++ b/lib/marshalls/provenance.marshall.js
@@ -4,6 +4,8 @@ const semver = require('semver')
 const BaseMarshall = require('./baseMarshall')
 const NpmRegistry = require('../helpers/npmRegistry')
 const Warning = require('../helpers/warning')
+const NotEvaluated = require('../helpers/notEvaluated')
+const { RegistryError } = require('../helpers/registryErrors')
 const { marshallCategories } = require('./constants')
 
 const MARSHALL_NAME = 'provenance'
@@ -88,115 +90,80 @@ class Marshall extends BaseMarshall {
     }
   }
 
-  validate(pkg) {
+  async validate(pkg) {
     const validationMetadata = {}
-    const npmRegistry = new NpmRegistry({
-      registry: 'https://registry.npmjs.org'
-    })
+    const verifier = new NpmRegistry()
 
-    return this.packageRepoUtils
-      .getPackageInfo(pkg.packageName)
-      .then(async (packageInfo) => {
-        const packageName = packageInfo.name
+    try {
+      const packageInfo = await this.packageRepoUtils.getPackageInfo(pkg.packageName)
+      validationMetadata.name = packageInfo.name
+      validationMetadata.version = await this.resolvePackageVersion(
+        pkg.packageName,
+        pkg.packageVersion,
+        packageInfo
+      )
+      validationMetadata.packageInfo = packageInfo
 
-        // Use the resolvePackageVersion method to handle version ranges properly
-        const packageVersion = await this.resolvePackageVersion(
-          pkg.packageName,
-          pkg.packageVersion,
-          packageInfo
+      if (!validationMetadata.version) {
+        throw new Error('Unable to find version or dist-tag for package')
+      }
+
+      const manifest = await this.registryClient.getManifest(
+        `${validationMetadata.name}@${validationMetadata.version}`,
+        packageInfo
+      )
+      let metadata
+      if (!manifest.dist || !manifest.dist.attestations) {
+        metadata = await verifier.verifyAttestations(manifest, [], null)
+      } else {
+        const [keys, attestations] = await Promise.all([
+          this.registryClient.getRegistryKeys(validationMetadata.name),
+          this.registryClient.getAttestations(validationMetadata.name, manifest)
+        ])
+        metadata = await verifier.verifyAttestations(manifest, keys, attestations)
+      }
+
+      if (!metadata || !metadata._attestations) {
+        this.throwIfProvenanceRegression(validationMetadata)
+        throw new Warning('the package was published without any attestations')
+      }
+      return metadata._attestations
+    } catch (error) {
+      if (error instanceof NotEvaluated || error instanceof RegistryError) {
+        throw error
+      }
+      if (error.code === 'EATTESTATIONVERIFY' && error.message.includes('malformed checkpoint')) {
+        return []
+      }
+      if (
+        error instanceof Error &&
+        error.message === 'Unable to find version or dist-tag for package'
+      ) {
+        throw error
+      }
+      if (
+        error instanceof Warning &&
+        error.message === 'the package was published without any attestations'
+      ) {
+        throw error
+      }
+      if (shouldConsiderProvenanceRegression(error)) {
+        this.throwIfProvenanceRegression(validationMetadata)
+      }
+      if (error.message.includes('Package has no attestations to verify')) {
+        throw new Warning(
+          'Unable to verify provenance: the package was published without any attestations'
         )
+      }
 
-        validationMetadata.name = packageName
-        validationMetadata.version = packageVersion
-        validationMetadata.packageInfo = packageInfo
-
-        if (!validationMetadata.version) {
-          throw new Error('Unable to find version or dist-tag for package')
-        }
-
-        return validationMetadata
-      })
-      .then((validationMetadata) => {
-        return this.fetchRegistryKeys().then((keys) => {
-          return npmRegistry
-            .getManifest(`${validationMetadata.name}@${validationMetadata.version}`)
-            .then((manifest) => npmRegistry.verifyAttestations(manifest, keys))
-        })
-      })
-      .then((metadata) => {
-        if (!metadata || !metadata._attestations) {
-          this.throwIfProvenanceRegression(validationMetadata)
-          throw new Warning('the package was published without any attestations')
-        }
-
-        const attestations = metadata._attestations
-        return attestations
-      })
-      .catch((error) => {
-        // We can ignore this type of error, false positive
-        // See: https://github.com/lirantal/npq/issues/329
-        if (error.code === 'EATTESTATIONVERIFY' && error.message.includes('malformed checkpoint')) {
-          return []
-        }
-
-        if (
-          error instanceof Error &&
-          error.message === 'Unable to find version or dist-tag for package'
-        ) {
-          throw error
-        }
-
-        if (
-          error instanceof Warning &&
-          (error.message.includes('Error fetching registry keys') ||
-            error.message === 'the package was published without any attestations')
-        ) {
-          throw error
-        }
-
-        if (shouldConsiderProvenanceRegression(error)) {
-          this.throwIfProvenanceRegression(validationMetadata)
-        }
-
-        if (error.message.includes('Package has no attestations to verify')) {
-          throw new Warning(
-            `Unable to verify provenance: the package was published without any attestations`
-          )
-        }
-
-        this.debug(
-          '\nUnable to verify provenance for package %s@%s: %s',
-          validationMetadata.name,
-          validationMetadata.version,
-          error.message
-        )
-        throw new Warning(`Unable to verify provenance`)
-      })
-  }
-
-  fetchRegistryKeys() {
-    const registryHost = 'https://registry.npmjs.org'
-    const registryKeysEndpoint = '/-/npm/v1/keys'
-
-    const registryKeysUrl = `${registryHost}${registryKeysEndpoint}`
-    return fetch(registryKeysUrl)
-      .then((response) => {
-        return response.json()
-      })
-      .then((response) => {
-        const registryKeys = response.keys
-
-        return registryKeys.map((key) => ({
-          ...key,
-          pemkey: `-----BEGIN PUBLIC KEY-----\n${key.key}\n-----END PUBLIC KEY-----`
-        }))
-      })
-      .then((keys) => {
-        return keys
-      })
-      .catch((error) => {
-        throw new Warning(`Error fetching registry keys: ${error.message}`)
-      })
+      this.debug(
+        '\nUnable to verify provenance for package %s@%s: %s',
+        validationMetadata.name,
+        validationMetadata.version,
+        error.message
+      )
+      throw new Warning('Unable to verify provenance')
+    }
   }
 }
 

--- a/lib/marshalls/signatures.marshall.js
+++ b/lib/marshalls/signatures.marshall.js
@@ -3,11 +3,11 @@
 const BaseMarshall = require('./baseMarshall')
 const Warning = require('../helpers/warning')
 const NpmRegistry = require('../helpers/npmRegistry')
+const NotEvaluated = require('../helpers/notEvaluated')
+const { RegistryError } = require('../helpers/registryErrors')
 const { marshallCategories } = require('./constants')
 
 const MARSHALL_NAME = 'signatures'
-
-let registryKeysCache = null
 
 class Marshall extends BaseMarshall {
   constructor(options) {
@@ -20,83 +20,44 @@ class Marshall extends BaseMarshall {
     return 'Verifying registry signatures for package'
   }
 
-  validate(pkg) {
-    const npmRegistry = new NpmRegistry({
-      registry: 'https://registry.npmjs.org'
-    })
+  async validate(pkg) {
+    const verifier = new NpmRegistry()
 
-    return this.packageRepoUtils
-      .getPackageInfo(pkg.packageName)
-      .then(async (packageInfo) => {
-        // Resolve version range to specific version
-        const resolvedVersion = await this.resolvePackageVersion(
-          pkg.packageName,
-          pkg.packageVersion,
-          packageInfo
+    try {
+      const packageInfo = await this.packageRepoUtils.getPackageInfo(pkg.packageName)
+      const resolvedVersion = await this.resolvePackageVersion(
+        pkg.packageName,
+        pkg.packageVersion,
+        packageInfo
+      )
+
+      if (!resolvedVersion) {
+        throw new Error(
+          `Unable to resolve version ${pkg.packageVersion} for package ${pkg.packageName}`
         )
+      }
 
-        if (!resolvedVersion) {
-          throw new Error(
-            `Unable to resolve version ${pkg.packageVersion} for package ${pkg.packageName}`
-          )
-        }
-
-        return { packageInfo, resolvedVersion }
-      })
-      .then(({ resolvedVersion }) => {
-        return this.fetchRegistryKeys().then((keys) => {
-          return npmRegistry
-            .getManifest(`${pkg.packageName}@${resolvedVersion}`)
-            .then((manifest) => npmRegistry.verifySignatures(manifest, keys))
-        })
-      })
-      .then((metadata) => {
-        return metadata
-      })
-      .catch((error) => {
-        // Handle specific error cases
-        if (
-          error.message &&
-          error.message.includes('but the corresponding public key has expired')
-        ) {
-          // if the error is about an expired key, we throw a warning
-          // instead of an error, so that the process can continue
-          throw new Warning(`Package is signed with an expired key`)
-        }
-
-        throw new Warning(`Unable to verify package signature on registry: ${error.message}`)
-      })
-  }
-
-  fetchRegistryKeys() {
-    if (registryKeysCache) {
-      return Promise.resolve(registryKeysCache)
+      const manifest = await this.registryClient.getManifest(
+        `${pkg.packageName}@${resolvedVersion}`,
+        packageInfo
+      )
+      if (!manifest.dist || !manifest.dist.signatures) {
+        return await verifier.verifySignatures(manifest, [])
+      }
+      const keys = await this.registryClient.getRegistryKeys(pkg.packageName)
+      return await verifier.verifySignatures(manifest, keys)
+    } catch (error) {
+      if (error instanceof NotEvaluated || error instanceof RegistryError) {
+        throw error
+      }
+      if (
+        error.message &&
+        error.message.includes('but the corresponding public key has expired')
+      ) {
+        throw new Warning('Package is signed with an expired key')
+      }
+      throw new Warning(`Unable to verify package signature on registry: ${error.message}`)
     }
-
-    const registryHost = 'https://registry.npmjs.org'
-    const registryKeysEndpoint = '/-/npm/v1/keys'
-
-    const registryKeysUrl = `${registryHost}${registryKeysEndpoint}`
-    return fetch(registryKeysUrl)
-      .then((response) => {
-        return response.json()
-      })
-      .then((response) => {
-        const registryKeys = response.keys
-
-        return registryKeys.map((key) => ({
-          ...key,
-          pemkey: `-----BEGIN PUBLIC KEY-----\n${key.key}\n-----END PUBLIC KEY-----`
-        }))
-      })
-      .then((keys) => {
-        // save it in the cached singleton object
-        registryKeysCache = keys
-        return keys
-      })
-      .catch((error) => {
-        throw new Warning(`Error fetching registry keys: ${error.message}`)
-      })
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0-development",
       "license": "Apache-2.0",
       "dependencies": {
+        "@npmcli/config": "^10.10.0",
         "npm-package-arg": "^13.0.2",
+        "npm-registry-fetch": "^19.1.1",
         "semver": "^7.7.4",
         "sigstore": "^4.1.0",
         "ssri": "^13.0.1"
@@ -824,6 +826,15 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1579,6 +1590,34 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/@npmcli/config": {
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/config/-/config-10.10.0.tgz",
+      "integrity": "sha512-Qpv1lFxJle2EmvskCmkVMPxWiiUeNZ7xyuUNHnvpmaellpVBIrYXQWysuKwHo/5G8WDaRkgnTyarL36/2Db76g==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/map-workspaces": "^5.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "ci-info": "^4.0.0",
+        "ini": "^6.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "walk-up-path": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/config/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/@npmcli/fs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
@@ -1587,6 +1626,320 @@
       "dependencies": {
         "semver": "^7.3.5"
       },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/git/-/git-7.0.2.tgz",
+      "integrity": "sha512-oeolHDjExNAJAnlYP2qzNjMX/Xi9bmu78C9dIGr4xjobrSKbuMYCph8lTzn4vnW3NjIqVmw/f8BCfouqyJXlRg==",
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/promise-spawn": "^9.0.0",
+        "ini": "^6.0.0",
+        "lru-cache": "^11.2.1",
+        "npm-pick-manifest": "^11.0.1",
+        "proc-log": "^6.0.0",
+        "semver": "^7.3.5",
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/git/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@npmcli/map-workspaces/-/map-workspaces-5.0.3.tgz",
+      "integrity": "sha512-o2grssXo1e774E5OtEwwrgoszYRh0lqkJH+Pb9r78UcqdGJRDRfhpM8DvZPjzNLLNYeD/rNbjOKM3Ss5UABROw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/name-from-folder": "^4.0.0",
+        "@npmcli/package-json": "^7.0.0",
+        "glob": "^13.0.0",
+        "minimatch": "^10.0.3"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/map-workspaces/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/name-from-folder": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/name-from-folder/-/name-from-folder-4.0.0.tgz",
+      "integrity": "sha512-qfrhVlOSqmKM8i6rkNdZzABj8MKEITGFAY+4teqBziksCQAOLutiAxM1wY2BKEd8KjUSpWmWCYxvXr0y4VTlPg==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@npmcli/package-json/-/package-json-7.0.5.tgz",
+      "integrity": "sha512-iVuTlG3ORq2iaVa1IWUxAO/jIp77tUKBhoMjuzYW2kL4MLN1bi/ofqkZ7D7OOwh8coAx1/S2ge0rMdGv8sLSOQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^7.0.0",
+        "glob": "^13.0.0",
+        "hosted-git-info": "^9.0.0",
+        "json-parse-even-better-errors": "^5.0.0",
+        "proc-log": "^6.0.0",
+        "semver": "^7.5.3",
+        "spdx-expression-parse": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@npmcli/package-json/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/promise-spawn/-/promise-spawn-9.0.1.tgz",
+      "integrity": "sha512-OLUaoqBuyxeTqUvjA3FZFiXUfYC1alp3Sa99gW3EUDz3tZ3CbXDdcZ7qWKBzicrJleIgucoWamWH1saAmH/l2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "which": "^6.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@npmcli/promise-spawn/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/@npmcli/redact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@npmcli/redact/-/redact-4.0.0.tgz",
+      "integrity": "sha512-gOBg5YHMfZy+TfHArfVogwgfBeQnKbbGo3pSUyK/gSI0AVu+pEiDVcKlQb0D8Mg1LNRZILZ6XG8I5dJ4KuAd9Q==",
+      "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
@@ -2842,6 +3195,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/abbrev": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3334,7 +3696,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
       "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6306,6 +6667,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-5.0.0.tgz",
+      "integrity": "sha512-ZF1nxZ28VhQouRWhUcVlUIN3qwSgPuswK05s/HIaoetAoE/9tngVmCHjSxmSQPav1nd+lPtTL0YZ/2AFdR/iYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -6345,6 +6715,15 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -7137,10 +7516,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -7351,6 +7730,21 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "6.0.2",
@@ -7565,6 +7959,27 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/npm-install-checks": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-8.0.0.tgz",
+      "integrity": "sha512-ScAUdMpyzkbpxoNekQ3tNRdFI8SJ86wgKZSQZdUxT+bj0wVFpsEMWnkXP0twVe1gJyNF5apBWDJhhIbgrIViRA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-5.0.0.tgz",
+      "integrity": "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/npm-package-arg": {
       "version": "13.0.2",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-13.0.2.tgz",
@@ -7575,6 +7990,40 @@
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^7.0.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-pick-manifest": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/npm-pick-manifest/-/npm-pick-manifest-11.0.3.tgz",
+      "integrity": "sha512-buzyCfeoGY/PxKqmBqn1IUJrZnUi1VVJTdSSRPGI60tJdUhUoSQFhs0zycJokDdOznQentgrpf8LayEHyyYlqQ==",
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^8.0.0",
+        "npm-normalize-package-bin": "^5.0.0",
+        "npm-package-arg": "^13.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm-registry-fetch": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-19.1.1.tgz",
+      "integrity": "sha512-TakBap6OM1w0H73VZVDf44iFXsOS3h+L4wVMXmbWOQroZgFhMch0juN6XSzBNlD965yIKvWg2dfu7NSiaYLxtw==",
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/redact": "^4.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^15.0.0",
+        "minipass": "^7.0.2",
+        "minipass-fetch": "^5.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^13.0.0",
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11010,7 +11459,6 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
-      "dev": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
@@ -11028,7 +11476,6 @@
       "version": "3.0.23",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/split2": {
@@ -11892,6 +12339,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/walk-up-path": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-4.0.0.tgz",
+      "integrity": "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==",
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/walker": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "access": "public"
   },
   "dependencies": {
+    "@npmcli/config": "^10.10.0",
     "npm-package-arg": "^13.0.2",
+    "npm-registry-fetch": "^19.1.1",
     "semver": "^7.7.4",
     "sigstore": "^4.1.0",
     "ssri": "^13.0.1"


### PR DESCRIPTION
## What changed

- load standard npm registry configuration, including default and scoped registries, authentication, proxies, TLS, and client certificates
- route package metadata, manifests, signing keys, and attestations through a shared authenticated registry client
- avoid public npm fallback for packages assigned to custom registries
- report unavailable signing, provenance, and download-count capabilities as `NOT EVALUATED` without changing install decisions
- document Artifactory-style configuration and add a minor changeset

## Why

NPQ previously hardcoded public npm endpoints, so private packages configured through `.npmrc` could not be audited consistently with the package manager. This change keeps audits in the selected registry context and makes unsupported optional services visible without treating them as package findings.

## Validation

- `npm test -- --runInBand` — 32 suites, 465 tests passed
- `npm run lint` — passed with zero errors
- `npm run build` — passed
- `git diff --check` — passed

## Related issues

Fixes: #429

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add authenticated custom-registry support by loading standard npm config and routing all registry calls through a shared client. Audits run in the same registry context as your package manager and show unsupported checks as NOT EVALUATED instead of failing. Fixes #429.

- **New Features**
  - Read standard npm config via `@npmcli/config` (default/scoped registries, auth, proxies, TLS, client certs).
  - Route metadata, manifests, signing keys, and attestations through one `RegistryClient` using `npm-registry-fetch`.
  - Preserve scoped registry routing and prevent fallback to the public npm registry for packages mapped to custom registries.
  - Record missing capabilities as "not evaluated" (signing keys, attestations, download counts) without changing install decisions; show them in the report.
  - CLI accepts and forwards `--registry`, `--userconfig`, and `--globalconfig` to the package manager; the same options drive the audit.
  - Docs added for Artifactory-style `.npmrc`, config precedence, private CAs, and privacy guarantees.

- **Dependencies**
  - Added `@npmcli/config` and `npm-registry-fetch`.

<sup>Written for commit 664c56cd8aa82edd741c57164a5530406413fe5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

