### PR TITLE
fix: false expired-domain error when package has no maintainers data

### DIFF
--- a/.changeset/brave-domains-check.md
+++ b/.changeset/brave-domains-check.md
@@ -1,0 +1,5 @@
+---
+'npq': patch
+---
+
+Report a missing or empty maintainers list as a not-evaluated check in the expired-domains marshall, instead of a false "expired domain can be abused for account takeover" error.

--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const ExpiredDomainsMarshall = require('../lib/marshalls/expiredDomains.marshall')
+const NotEvaluated = require('../lib/helpers/notEvaluated')
 
 const testMarshall = new ExpiredDomainsMarshall({
   packageRepoUtils: {
@@ -73,6 +74,46 @@ describe('Expired domains test suites', () => {
     await expect(testMarshall.validate(pkgData)).rejects.toThrow(
       /Detected expired domain can be abused for account takeover: <unknown>/
     )
+  })
+
+  test('is not evaluated when the latest version has no maintainers data', async () => {
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {}
+        }
+      }
+    }
+
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(NotEvaluated)
+  })
+
+  test('is not evaluated when the maintainers list is empty', async () => {
+    const pkgData = {
+      packageName: {
+        'dist-tags': {
+          latest: '1.0.0'
+        },
+        versions: {
+          '1.0.0': {
+            maintainers: []
+          }
+        }
+      }
+    }
+
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(NotEvaluated)
+  })
+
+  test('is not evaluated when the package data has no versions', async () => {
+    const pkgData = {
+      packageName: {}
+    }
+
+    await expect(testMarshall.validate(pkgData)).rejects.toThrow(NotEvaluated)
   })
 
   test('does not throw any errors if the domain resolves well', async () => {

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -2,6 +2,7 @@
 
 const BaseMarshall = require('./baseMarshall')
 const { marshallCategories } = require('./constants')
+const NotEvaluated = require('../helpers/notEvaluated')
 const { Resolver } = require('dns/promises')
 
 const dns = new Resolver()
@@ -28,6 +29,10 @@ class Marshall extends BaseMarshall {
 
         const maintainersAccounts = lastVersionData && lastVersionData.maintainers
 
+        if (!Array.isArray(maintainersAccounts) || maintainersAccounts.length === 0) {
+          throw new NotEvaluated('no maintainers information available for the package')
+        }
+
         const testEmails = []
         for (const maintainerInfo of maintainersAccounts) {
           const maintainerEmail = maintainerInfo.email
@@ -38,6 +43,10 @@ class Marshall extends BaseMarshall {
         return Promise.all(testEmails)
       })
       .catch((error) => {
+        if (error instanceof NotEvaluated) {
+          throw error
+        }
+
         const emailHostname = error.hostname ? error.hostname : '<unknown>'
         this.debug('\nDetected error resolving domain for maintainer e-mail: %s', emailHostname)
         throw new Error(


### PR DESCRIPTION
## Description
The expired-domains marshall blows up when the package data has no maintainers (or no versions at all): the loop at `expiredDomains.marshall.js` throws a `TypeError`, and the catch-all turns it into "Detected expired domain can be abused for account takeover..." - a false positive

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Related Issue
https://github.com/lirantal/npq/issues/436

## Motivation and Context
There are packages with no maintainers (like this one... 🤓)

## How Has This Been Tested?
- 3 new tests (no maintainers / empty maintainers / no versions) — all fail without the  fix with the account-takeover message.
- Full suite passes (473 tests), coverage thresholds OK, lint clean. Changeset included.

## Screenshots (if appropriate):
Nope.

## Checklist:
- [ ] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false "expired domain can be abused for account takeover" error when a package has no maintainers or versions by marking the check as not evaluated in the expired-domains marshall.

- **Bug Fixes**
  - In `expiredDomains.marshall.js`, throw `NotEvaluated` when the latest version has no `maintainers`, the list is empty, or the package has no `versions`.
  - Let `NotEvaluated` propagate without converting it to the generic expired-domain error.
  - Added tests for all three cases.

<sup>Written for commit de75fad98abba198ce11fb8cc3b3b7fee43fcf99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/437?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

