### PR TITLE
fix: isolate expired-domain validation failures 🤖🤖🤖

### DIFF
--- a/.changeset/calm-domains-validate.md
+++ b/.changeset/calm-domains-validate.md
@@ -1,0 +1,5 @@
+---
+'npq': patch
+---
+
+Keep registry and malformed maintainer metadata failures from being reported as expired-domain account-takeover findings.

--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -2,142 +2,112 @@
 
 const ExpiredDomainsMarshall = require('../lib/marshalls/expiredDomains.marshall')
 const NotEvaluated = require('../lib/helpers/notEvaluated')
+const { RegistryError } = require('../lib/helpers/registryErrors')
 
-const testMarshall = new ExpiredDomainsMarshall({
-  packageRepoUtils: {
-    getPackageInfo: (pkgInfo) => {
-      return new Promise((resolve) => {
-        resolve(pkgInfo)
-      })
+function packageData(maintainers) {
+  return {
+    'dist-tags': { latest: '1.0.0' },
+    versions: {
+      '1.0.0': { maintainers }
     }
   }
-})
+}
+
+function createMarshall({ getPackageInfo, resolve } = {}) {
+  return new ExpiredDomainsMarshall({
+    packageRepoUtils: {
+      getPackageInfo: getPackageInfo || (async (pkgInfo) => pkgInfo)
+    },
+    dnsResolver: {
+      resolve: resolve || jest.fn().mockResolvedValue(['ns1.example.com'])
+    }
+  })
+}
 
 describe('Expired domains test suites', () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-    jest.resetAllMocks()
+  test('has the right title', () => {
+    expect(createMarshall().title()).toEqual('Detecting expired domains for authors account...')
   })
 
-  test('has the right title', async () => {
-    expect(testMarshall.title()).toEqual('Detecting expired domains for authors account...')
+  test('isolates DNS failures from package metadata retrieval', async () => {
+    const failure = Object.assign(new Error('not found'), {
+      hostname: 'missing.example'
+    })
+    const resolve = jest.fn().mockRejectedValue(failure)
+    const testMarshall = createMarshall({ resolve })
+
+    await expect(
+      testMarshall.validate({
+        packageName: packageData([{ name: 'maintainer', email: 'dev@missing.example' }])
+      })
+    ).rejects.toThrow('Detected expired domain can be abused for account takeover: missing.example')
+    expect(resolve).toHaveBeenCalledWith('missing.example', 'NS')
   })
 
-  test('throws the right error when an email domain cant be verified', async () => {
-    const nonExistentEmailAddress =
-      'liran.tal+test1234@somenonexistentdomainongoogle109dubv98g39ujasdasda.com'
-    const pkgData = {
-      packageName: {
-        'dist-tags': {
-          latest: '1.0.0'
-        },
-        versions: {
-          '1.0.0': {
-            maintainers: [
-              { name: 'lirantal', email: 'liran.tal@gmail.com' },
-              {
-                name: 'lirantal_test_user',
-                email: nonExistentEmailAddress
-              }
-            ]
-          }
-        }
-      }
-    }
+  test('preserves registry errors', async () => {
+    const failure = new RegistryError('Registry network request failed', {
+      registry: 'https://registry.example.test/',
+      code: 'EREGISTRYNETWORK'
+    })
+    const testMarshall = createMarshall({
+      getPackageInfo: jest.fn().mockRejectedValue(failure)
+    })
 
-    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
-      /Detected expired domain can be abused for account takeover/
+    await expect(testMarshall.validate({ packageName: 'example' })).rejects.toBe(failure)
+  })
+
+  test.each([
+    ['missing email', { name: 'maintainer' }],
+    ['empty email', { name: 'maintainer', email: '' }],
+    ['email without a domain', { name: 'maintainer', email: 'dev@' }],
+    ['email with whitespace in its domain', { name: 'maintainer', email: 'dev@example .com' }]
+  ])('is not evaluated for a %s', async (_name, maintainer) => {
+    const resolve = jest.fn()
+    const testMarshall = createMarshall({ resolve })
+
+    await expect(testMarshall.validate({ packageName: packageData([maintainer]) })).rejects.toThrow(
+      NotEvaluated
     )
+    expect(resolve).not.toHaveBeenCalled()
   })
 
-  test('if email hostname is empty then show an unknown message', async () => {
-    const nonExistentEmailAddress = ''
-    const pkgData = {
-      packageName: {
-        'dist-tags': {
-          latest: '1.0.0'
-        },
-        versions: {
-          '1.0.0': {
-            maintainers: [
-              { name: 'lirantal', email: 'liran.tal@gmail.com' },
-              {
-                name: 'lirantal_test_user',
-                email: nonExistentEmailAddress
-              }
-            ]
-          }
-        }
-      }
-    }
+  test('checks valid emails but reports mixed maintainer data as not evaluated', async () => {
+    const resolve = jest.fn().mockResolvedValue(['ns1.example.com'])
+    const testMarshall = createMarshall({ resolve })
 
-    await expect(testMarshall.validate(pkgData)).rejects.toThrow(
-      /Detected expired domain can be abused for account takeover: <unknown>/
-    )
+    await expect(
+      testMarshall.validate({
+        packageName: packageData([
+          { name: 'valid', email: 'dev@example.com' },
+          { name: 'invalid', email: '' }
+        ])
+      })
+    ).rejects.toThrow('1 maintainer email address is missing or malformed')
+    expect(resolve).toHaveBeenCalledWith('example.com', 'NS')
   })
 
-  test('is not evaluated when the latest version has no maintainers data', async () => {
-    const pkgData = {
-      packageName: {
-        'dist-tags': {
-          latest: '1.0.0'
-        },
-        versions: {
-          '1.0.0': {}
-        }
-      }
-    }
+  test.each([
+    ['latest version has no maintainers data', packageData(undefined)],
+    ['maintainers list is empty', packageData([])],
+    ['package data has no versions', {}]
+  ])('is not evaluated when the %s', async (_name, data) => {
+    const testMarshall = createMarshall()
 
-    await expect(testMarshall.validate(pkgData)).rejects.toThrow(NotEvaluated)
+    await expect(testMarshall.validate({ packageName: data })).rejects.toThrow(NotEvaluated)
   })
 
-  test('is not evaluated when the maintainers list is empty', async () => {
-    const pkgData = {
-      packageName: {
-        'dist-tags': {
-          latest: '1.0.0'
-        },
-        versions: {
-          '1.0.0': {
-            maintainers: []
-          }
-        }
-      }
-    }
+  test('resolves without live network access when every domain resolves', async () => {
+    const resolve = jest.fn().mockResolvedValue(['ns1.example.com'])
+    const testMarshall = createMarshall({ resolve })
 
-    await expect(testMarshall.validate(pkgData)).rejects.toThrow(NotEvaluated)
-  })
-
-  test('is not evaluated when the package data has no versions', async () => {
-    const pkgData = {
-      packageName: {}
-    }
-
-    await expect(testMarshall.validate(pkgData)).rejects.toThrow(NotEvaluated)
-  })
-
-  test('does not throw any errors if the domain resolves well', async () => {
-    jest.setTimeout(15000)
-
-    const pkgData = {
-      packageName: {
-        'dist-tags': {
-          latest: '1.0.0'
-        },
-        versions: {
-          '1.0.0': {
-            maintainers: [
-              { name: 'lirantal', email: 'liran.tal@gmail.com' },
-              {
-                name: 'lirantal_test_user',
-                email: 'liran.tal@gmail.com'
-              }
-            ]
-          }
-        }
-      }
-    }
-
-    await expect(testMarshall.validate(pkgData)).resolves.toEqual(expect.anything())
+    await expect(
+      testMarshall.validate({
+        packageName: packageData([
+          { name: 'first', email: 'first@example.com' },
+          { name: 'second', email: 'second@example.org' }
+        ])
+      })
+    ).resolves.toEqual([['ns1.example.com'], ['ns1.example.com']])
+    expect(resolve).toHaveBeenCalledTimes(2)
   })
 })

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -14,45 +14,62 @@ class Marshall extends BaseMarshall {
     super(options)
     this.name = MARSHALL_NAME
     this.categoryId = marshallCategories.PackageHealth.id
+    this.dnsResolver = options.dnsResolver || dns
   }
 
   title() {
     return 'Detecting expired domains for authors account...'
   }
 
-  validate(pkg) {
-    return this.packageRepoUtils
-      .getPackageInfo(pkg.packageName)
-      .then((data) => {
-        const lastVersionData =
-          data.versions && data['dist-tags'] && data.versions[data['dist-tags'].latest]
+  async validate(pkg) {
+    const data = await this.packageRepoUtils.getPackageInfo(pkg.packageName)
+    const lastVersionData =
+      data.versions && data['dist-tags'] && data.versions[data['dist-tags'].latest]
 
-        const maintainersAccounts = lastVersionData && lastVersionData.maintainers
+    const maintainersAccounts = lastVersionData && lastVersionData.maintainers
 
-        if (!Array.isArray(maintainersAccounts) || maintainersAccounts.length === 0) {
-          throw new NotEvaluated('no maintainers information available for the package')
-        }
+    if (!Array.isArray(maintainersAccounts) || maintainersAccounts.length === 0) {
+      throw new NotEvaluated('no maintainers information available for the package')
+    }
 
-        const testEmails = []
-        for (const maintainerInfo of maintainersAccounts) {
-          const maintainerEmail = maintainerInfo.email
-          const emailDomain = maintainerEmail.split('@')[1]
-          testEmails.push(dns.resolve(emailDomain, 'NS'))
-        }
+    const emailDomains = []
+    let invalidMaintainers = 0
+    for (const maintainerInfo of maintainersAccounts) {
+      const maintainerEmail = maintainerInfo && maintainerInfo.email
+      const atIndex = typeof maintainerEmail === 'string' ? maintainerEmail.lastIndexOf('@') : -1
+      const emailDomain = atIndex > 0 ? maintainerEmail.slice(atIndex + 1).trim() : ''
 
-        return Promise.all(testEmails)
-      })
-      .catch((error) => {
-        if (error instanceof NotEvaluated) {
-          throw error
-        }
+      if (!emailDomain || emailDomain.includes('@') || /\s/.test(emailDomain)) {
+        invalidMaintainers += 1
+        continue
+      }
 
-        const emailHostname = error.hostname ? error.hostname : '<unknown>'
-        this.debug('\nDetected error resolving domain for maintainer e-mail: %s', emailHostname)
-        throw new Error(
-          'Detected expired domain can be abused for account takeover: ' + emailHostname
-        )
-      })
+      emailDomains.push(emailDomain)
+    }
+
+    if (emailDomains.length === 0) {
+      throw new NotEvaluated('no valid maintainer email domains are available for the package')
+    }
+
+    let resolutionResults
+    try {
+      resolutionResults = await Promise.all(
+        emailDomains.map((emailDomain) => this.dnsResolver.resolve(emailDomain, 'NS'))
+      )
+    } catch (error) {
+      const emailHostname = error.hostname ? error.hostname : '<unknown>'
+      this.debug('\nDetected error resolving domain for maintainer e-mail: %s', emailHostname)
+      throw new Error(
+        'Detected expired domain can be abused for account takeover: ' + emailHostname
+      )
+    }
+
+    if (invalidMaintainers > 0) {
+      const noun = invalidMaintainers === 1 ? 'address is' : 'addresses are'
+      throw new NotEvaluated(`${invalidMaintainers} maintainer email ${noun} missing or malformed`)
+    }
+
+    return resolutionResults
   }
 }
 


### PR DESCRIPTION
## Summary

- isolate registry/metadata failures from account-takeover findings
- preserve RegistryError and NotEvaluated outcomes unchanged
- validate maintainer email records before DNS work
- inject the DNS resolver and replace live-network tests with deterministic mocks

## Why

The original promise chain could catch failures outside DNS resolution and relabel them as an expired-domain finding. This phase narrows each failure boundary so malformed metadata and registry failures cannot become false takeover signals.

## User impact

Registry failures retain their actual error, incomplete maintainer metadata is not evaluated, and production behavior keeps the existing public DNS resolver.

## Stack

Phase 1 of 4. Base: `main`. Merge this PR before the later phases.

## Validation

- `npm test -- --runInBand --testPathIgnorePatterns=/workspaces/npq/\.worktrees/`
- `npm run lint`
- `npm run build`

A patch changeset is included.

## Related issues

Refs: #440

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated the expired-domain check so registry and malformed maintainer metadata errors no longer show up as account-takeover findings. Added maintainer email validation and DNS resolver injection; tests now use deterministic DNS mocks.

- **Bug Fixes**
  - Prevented registry failures and bad maintainer metadata from being misreported as expired-domain takeover.
  - Preserved `RegistryError` and `NotEvaluated` outcomes; only DNS failures surface as takeover, with the specific hostname.
  - Validated maintainer email domains before DNS; missing/malformed emails return `NotEvaluated` with a clear count.

- **Refactors**
  - Injected `dnsResolver` (defaults to Node `dns`) to decouple network calls.
  - Replaced live-network tests with deterministic mocks.

<sup>Written for commit 71e73c506dde4cc9066e08c7a9c940fd16fe99ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

