### PR TITLE
fix(cli): handle pnpm filter argument ordering 🤖🤖🤖

### DIFF
--- a/.changeset/safe-pnpm-filters.md
+++ b/.changeset/safe-pnpm-filters.md
@@ -1,0 +1,5 @@
+---
+'npq': patch
+---
+
+Recognize filtered pnpm install and add commands regardless of filter placement, while excluding workspace selectors from package audits.

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ NPQ_PKG_MGR=pnpm npx npq install fastify
 
 ```bash
 alias pnpm="NPQ_PKG_MGR=pnpm npq-hero"
+pnpm --filter workspace... add express
 ```
 
 Note: `npq` by default will offload all commands and their arguments to the `npm` (or other package manager as specified) after it finished its due-diligence checks for the respective packages.

--- a/__tests__/cli.packageManagerArgs.test.js
+++ b/__tests__/cli.packageManagerArgs.test.js
@@ -1,0 +1,186 @@
+'use strict'
+
+const { CliParser } = require('../lib/cli')
+
+describe('package-manager-aware minimal argument parsing', () => {
+  let originalArgv
+  let originalNPQPkgMgr
+
+  beforeEach(() => {
+    originalArgv = process.argv
+    originalNPQPkgMgr = process.env.NPQ_PKG_MGR
+    process.argv = ['node', 'npq-hero']
+    delete process.env.NPQ_PKG_MGR
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    if (originalNPQPkgMgr === undefined) {
+      delete process.env.NPQ_PKG_MGR
+    } else {
+      process.env.NPQ_PKG_MGR = originalNPQPkgMgr
+    }
+  })
+
+  const parseMinimal = ({ packageManager, args }) => {
+    if (packageManager === undefined) {
+      delete process.env.NPQ_PKG_MGR
+    } else {
+      process.env.NPQ_PKG_MGR = packageManager
+    }
+    process.argv = ['node', 'npq-hero', ...args]
+    return CliParser.parseArgsMinimal()
+  }
+
+  test('finds an add command after a pnpm filter', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['--filter', 'workspace', 'add', 'express']
+    })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test('excludes a trailing pnpm filter selector from packages', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['add', 'express', '--filter', 'workspace']
+    })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test('excludes a pnpm filter between package operands', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['add', 'express', '--filter', 'workspace', 'lodash']
+    })
+
+    expect(result.packages).toEqual(['express@latest', 'lodash@latest'])
+  })
+
+  test.each([
+    ['equals', ['--filter=workspace', 'add', 'express']],
+    ['short', ['-F', 'workspace', 'add', 'express']]
+  ])('supports the pnpm %s filter form', (_form, args) => {
+    const result = parseMinimal({ packageManager: 'pnpm', args })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test('supports multiple pnpm filters', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: [
+        '--filter',
+        'workspace',
+        '--filter',
+        '@scope/*',
+        '--filter-prod',
+        'production',
+        'add',
+        'express'
+      ]
+    })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test.each(['workspace...', '...workspace'])('excludes the pnpm %s selector', (selector) => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['--filter', selector, 'add', 'express']
+    })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test('does not treat a filter selector named install as the command', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['--filter', 'install', 'add', 'express']
+    })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test('does not treat a pnpm selector after install as a package', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['install', '--filter', 'workspace...']
+    })
+
+    expect(result.packages).toEqual([])
+  })
+
+  test('keeps a package named install when it is an add operand', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['add', 'install', '--filter', 'workspace']
+    })
+
+    expect(result.packages).toEqual(['install@latest'])
+  })
+
+  test('keeps filtered non-install commands in passthrough mode', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: ['--filter', 'workspace', 'test']
+    })
+
+    expect(result.packages).toEqual([])
+  })
+
+  test.each([
+    ['run', 'install'],
+    ['exec', 'install']
+  ])('does not inspect pnpm %s %s as an install command', (...args) => {
+    const result = parseMinimal({ packageManager: 'pnpm', args })
+
+    expect(result.packages).toEqual([])
+  })
+
+  test('composes pnpm filters with registry configuration', () => {
+    const result = parseMinimal({
+      packageManager: 'pnpm',
+      args: [
+        '--filter',
+        'workspace',
+        'add',
+        '@company/tool',
+        '--registry=https://registry.example.test/npm/',
+        '--userconfig',
+        '/tmp/user.npmrc',
+        '--globalconfig=/tmp/global.npmrc'
+      ]
+    })
+
+    expect(result).toEqual({
+      packages: ['@company/tool@latest'],
+      registryConfigArgs: [
+        '--registry=https://registry.example.test/npm/',
+        '--userconfig=/tmp/user.npmrc',
+        '--globalconfig=/tmp/global.npmrc'
+      ]
+    })
+  })
+
+  test.each([
+    ['default npm', undefined, ['install', 'express']],
+    ['npm', 'npm', ['install', 'express']],
+    ['yarn', 'yarn', ['add', 'express']]
+  ])('preserves %s package parsing', (_label, packageManager, args) => {
+    const result = parseMinimal({ packageManager, args })
+
+    expect(result.packages).toEqual(['express@latest'])
+  })
+
+  test.each(['npm', 'yarn'])('does not apply the pnpm filter schema to %s', (packageManager) => {
+    const result = parseMinimal({
+      packageManager,
+      args: ['--filter', 'workspace', 'add', 'express']
+    })
+
+    expect(result.packages).toEqual([])
+  })
+})

--- a/__tests__/packageManager.test.js
+++ b/__tests__/packageManager.test.js
@@ -115,6 +115,21 @@ test('package manager spawns with pnpm when provided as parameter', async () => 
   childProcess.spawn.mockReset()
 })
 
+test.each([
+  ['before add', ['--filter', 'workspace...', 'add', 'express']],
+  ['after install', ['install', 'express', '--filter', '...workspace']]
+])('pnpm preserves filter and ellipsis selector order %s', async (_placement, args) => {
+  childProcess.spawn.mockImplementation(() => createMockChild(0))
+  process.argv = ['node', 'script name', ...args]
+
+  await packageManager.process('pnpm')
+
+  expect(childProcess.spawn).toHaveBeenCalledWith(`pnpm ${args.join(' ')}`, {
+    stdio: 'inherit',
+    shell: true
+  })
+})
+
 test('package manager forwards custom registry options', async () => {
   childProcess.spawn.mockImplementation(() => createMockChild(0))
   process.argv = [

--- a/docs/feature/alias.md
+++ b/docs/feature/alias.md
@@ -82,6 +82,17 @@ alias pnpm="NPQ_PKG_MGR=pnpm npq-hero"
 
 The `NPQ_PKG_MGR` environment variable tells npq which package manager to delegate to after completing its checks.
 
+### Filtered pnpm installs
+
+For pnpm aliases, filter options may appear before or after an `install` or `add` command. npq audits the registry package operands and then passes the original arguments to pnpm in their original order:
+
+```bash
+pnpm --filter workspace... add express
+pnpm install express --filter ...workspace
+```
+
+The values following `--filter`, `-F`, and `--filter-prod` select pnpm workspaces. These selectors are not registry packages, so npq does not audit them as package dependencies.
+
 ## Exit Code Preservation
 
 A critical requirement for the alias feature is that npq must preserve the exit code of the underlying package manager. Without this, CI pipelines and scripts that depend on exit codes (e.g. `npm audit` returning `1` when vulnerabilities are found) would silently pass.

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -3,6 +3,7 @@
 const { parseArgs } = require('node:util')
 const npa = require('npm-package-arg')
 const pkg = require('../package.json')
+const { parsePackageManagerArguments } = require('./helpers/packageManagerArgumentParser')
 
 const INSTALL_SUBCOMMANDS = new Set([
   'install',
@@ -145,22 +146,11 @@ curated by Liran Tal at https://github.com/lirantal/npq`)
   }
 
   static parseArgsMinimal() {
-    const config = {
-      allowPositionals: true,
-      strict: false,
-      options: {
-        install: {
-          type: 'string',
-          short: 'i',
-          default: 'install'
-        },
-        registry: { type: 'string' },
-        userconfig: { type: 'string' },
-        globalconfig: { type: 'string' }
-      }
-    }
-
-    const { values, positionals } = parseArgs(config)
+    const packageManager = process.env.NPQ_PKG_MGR || 'npm'
+    const { values, positionals } = parsePackageManagerArguments({
+      packageManager,
+      args: process.argv.slice(2)
+    })
 
     const earlyExitNoInstall = true
     const normalizedPackages = this._extractPackagesFromPositionals(positionals, earlyExitNoInstall)

--- a/lib/helpers/packageManagerArgumentParser.js
+++ b/lib/helpers/packageManagerArgumentParser.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const { parseArgs } = require('node:util')
+
+const BASE_OPTIONS = {
+  install: {
+    type: 'string',
+    short: 'i',
+    default: 'install'
+  },
+  registry: { type: 'string' },
+  userconfig: { type: 'string' },
+  globalconfig: { type: 'string' }
+}
+
+function parsePackageManagerArguments({ packageManager, args }) {
+  const options =
+    packageManager === 'pnpm'
+      ? {
+          ...BASE_OPTIONS,
+          filter: { type: 'string', short: 'F', multiple: true },
+          'filter-prod': { type: 'string', multiple: true }
+        }
+      : BASE_OPTIONS
+
+  const config = {
+    allowPositionals: true,
+    strict: false,
+    options
+  }
+
+  if (args !== undefined) {
+    config.args = args
+  }
+
+  return parseArgs(config)
+}
+
+module.exports.parsePackageManagerArguments = parsePackageManagerArguments


### PR DESCRIPTION
## Summary

- recognize pnpm `--filter`/`-F` and `--filter-prod` options when they appear before or after `install`/`add`
- exclude workspace selectors, including ellipsis forms, from registry package audits
- preserve existing `npq` full parsing, npm/yarn fallback behavior, and original package-manager argument passthrough
- document filtered pnpm alias usage and add a patch changeset

## Root cause

`npq-hero` used `node:util.parseArgs` with unknown pnpm options in non-strict mode. A separate `--filter` value was therefore left in the positional arguments, which could hide the real install command or be mistaken for a package to audit.

## Validation

- focused pnpm passthrough tests: 18/18
- parser, compatibility, passthrough, and exit-code tests: 91/91
- full test suite: 535/535
- `npm run lint` (0 errors; existing warnings only)
- `npm run build`
- independent task and whole-branch reviews found no issues

## Related issues

Fixes: #427


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `pnpm` filter handling in the `npq-hero` CLI so filtered `install`/`add` work regardless of filter placement, and workspace selectors aren’t audited as packages. Keeps passthrough behavior and `npm`/`yarn` parsing unchanged. Fixes #427.

- **Bug Fixes**
  - Recognize `--filter`, `-F`, and `--filter-prod` before or after `install`/`add`; supports multiple filters.
  - Exclude workspace selectors (e.g., `workspace...`, `...workspace`) from the audit package list.
  - Preserve original argument order when delegating to `pnpm`; works with `--registry`, `--userconfig`, and `--globalconfig`.

- **Refactors**
  - Added `lib/helpers/packageManagerArgumentParser.js` and routed `lib/cli` minimal parsing through it.
  - Expanded tests for `pnpm` filter scenarios and updated docs (`README.md`, `docs/feature/alias.md`); added a patch changeset.

<sup>Written for commit c4402a2bfd9d0b153d5fe8723d95c5db11f2bdb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

