### PR TITLE
fix: inspect resolved version for expired domains 🤖🤖🤖

### DIFF
--- a/.changeset/resolved-expired-domain-version.md
+++ b/.changeset/resolved-expired-domain-version.md
@@ -1,0 +1,5 @@
+---
+'npq': patch
+---
+
+Check expired-domain risk using maintainers from the package version being installed instead of always using the latest release.

--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -15,6 +15,18 @@ function packageData(maintainers) {
   }
 }
 
+function packageDataWithVersionedMaintainers() {
+  return {
+    'dist-tags': { latest: '2.0.0', next: '3.0.0' },
+    versions: {
+      '1.0.0': { maintainers: [{ name: 'exact', email: 'dev@exact.example.dev' }] },
+      '1.1.0': { maintainers: [{ name: 'range', email: 'dev@range.example.dev' }] },
+      '2.0.0': { maintainers: [{ name: 'latest', email: 'dev@latest.example.dev' }] },
+      '3.0.0': { maintainers: [{ name: 'next', email: 'dev@next.example.dev' }] }
+    }
+  }
+}
+
 function dnsFailure(code, hostname = 'example.com') {
   return Object.assign(new Error(code), { code, hostname })
 }
@@ -22,7 +34,8 @@ function dnsFailure(code, hostname = 'example.com') {
 function createMarshall({ getPackageInfo, resolve, rdapLookup } = {}) {
   return new ExpiredDomainsMarshall({
     packageRepoUtils: {
-      getPackageInfo: getPackageInfo || (async (pkgInfo) => pkgInfo)
+      getPackageInfo: getPackageInfo || (async (pkgInfo) => pkgInfo),
+      parsePackageVersion: () => null
     },
     dnsResolver: {
       resolve: resolve || jest.fn().mockResolvedValue(['ns1.example.com'])
@@ -51,6 +64,36 @@ describe('Expired domains test suites', () => {
   })
 
   test.each([
+    ['an exact older version', '1.0.0', 'exact.example.dev'],
+    ['a semver range', '^1.0.0', 'range.example.dev'],
+    ['a non-latest dist-tag', 'next', 'next.example.dev']
+  ])('checks maintainers for %s', async (_case, packageVersion, expectedDomain) => {
+    const resolve = jest.fn().mockResolvedValue(['ns1.example.com'])
+    const testMarshall = createMarshall({ resolve })
+
+    await testMarshall.validate({
+      packageName: packageDataWithVersionedMaintainers(),
+      packageVersion
+    })
+
+    expect(resolve).toHaveBeenCalledWith(expectedDomain, 'NS')
+    expect(resolve).not.toHaveBeenCalledWith('latest.example.dev', 'NS')
+  })
+
+  test('is not evaluated for an unresolvable selector', async () => {
+    const resolve = jest.fn()
+    const testMarshall = createMarshall({ resolve })
+
+    await expect(
+      testMarshall.validate({
+        packageName: packageDataWithVersionedMaintainers(),
+        packageVersion: 'unknown'
+      })
+    ).rejects.toThrow(NotEvaluated)
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
+  test.each([
     ['missing email', { name: 'maintainer' }],
     ['empty email', { name: 'maintainer', email: '' }],
     ['email without a domain', { name: 'maintainer', email: 'dev@' }],
@@ -59,9 +102,9 @@ describe('Expired domains test suites', () => {
     const resolve = jest.fn()
     const testMarshall = createMarshall({ resolve })
 
-    await expect(testMarshall.validate({ packageName: packageData([maintainer]) })).rejects.toThrow(
-      NotEvaluated
-    )
+    await expect(
+      testMarshall.validate({ packageName: packageData([maintainer]), packageVersion: 'latest' })
+    ).rejects.toThrow(NotEvaluated)
     expect(resolve).not.toHaveBeenCalled()
   })
 
@@ -72,7 +115,9 @@ describe('Expired domains test suites', () => {
   ])('is not evaluated when the %s', async (_name, data) => {
     const testMarshall = createMarshall()
 
-    await expect(testMarshall.validate({ packageName: data })).rejects.toThrow(NotEvaluated)
+    await expect(
+      testMarshall.validate({ packageName: data, packageVersion: 'latest' })
+    ).rejects.toThrow(NotEvaluated)
   })
 
   test('reports NXDOMAIN as a warning instead of an error', async () => {
@@ -86,7 +131,8 @@ describe('Expired domains test suites', () => {
 
     await expect(
       testMarshall.validate({
-        packageName: packageData([{ name: 'maintainer', email: 'dev@missing-domain.com' }])
+        packageName: packageData([{ name: 'maintainer', email: 'dev@missing-domain.com' }]),
+        packageVersion: 'latest'
       })
     ).rejects.toEqual(
       expect.objectContaining({
@@ -105,7 +151,8 @@ describe('Expired domains test suites', () => {
 
       await expect(
         testMarshall.validate({
-          packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }])
+          packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }]),
+          packageVersion: 'latest'
         })
       ).rejects.toThrow(NotEvaluated)
     }
@@ -161,7 +208,8 @@ describe('Expired domains test suites', () => {
           { name: 'invalid', email: '' },
           { name: 'timeout', email: 'dev@timeout-domain.com' },
           { name: 'a', email: 'dev@a-domain.com' }
-        ])
+        ]),
+        packageVersion: 'latest'
       })
     ).rejects.toThrow(
       'Maintainer domains a-domain.com, b-domain.com do not resolve in public DNS, and RDAP found no active registration; account takeover may be possible. 2 other maintainer records could not be evaluated.'
@@ -181,7 +229,8 @@ describe('Expired domains test suites', () => {
 
     await expect(
       testMarshall.validate({
-        packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }])
+        packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }]),
+        packageVersion: 'latest'
       })
     ).resolves.toEqual([undefined])
     expect(rdapLookup).toHaveBeenCalledWith('public-domain.com')
@@ -201,7 +250,8 @@ describe('Expired domains test suites', () => {
 
     await expect(
       testMarshall.validate({
-        packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }])
+        packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }]),
+        packageVersion: 'latest'
       })
     ).rejects.toThrow(NotEvaluated)
   })
@@ -213,7 +263,8 @@ describe('Expired domains test suites', () => {
 
     await expect(
       testMarshall.validate({
-        packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }])
+        packageName: packageData([{ name: 'maintainer', email: 'dev@public-domain.com' }]),
+        packageVersion: 'latest'
       })
     ).resolves.toEqual([['ns1.example.com']])
     expect(rdapLookup).not.toHaveBeenCalled()
@@ -224,7 +275,8 @@ describe('Expired domains test suites', () => {
     const testMarshall = createMarshall({ resolve })
 
     await testMarshall.validate({
-      packageName: packageData([{ name: 'maintainer', email: 'dev@MAIL.Example.CO.UK.' }])
+      packageName: packageData([{ name: 'maintainer', email: 'dev@MAIL.Example.CO.UK.' }]),
+      packageVersion: 'latest'
     })
 
     expect(resolve).toHaveBeenCalledWith('mail.example.co.uk', 'NS')
@@ -237,7 +289,8 @@ describe('Expired domains test suites', () => {
 
     await expect(
       testMarshall.validate({
-        packageName: packageData([{ name: 'maintainer', email: 'dev@example.co.uk' }])
+        packageName: packageData([{ name: 'maintainer', email: 'dev@example.co.uk' }]),
+        packageVersion: 'latest'
       })
     ).rejects.toThrow(NotEvaluated)
     expect(resolve).toHaveBeenCalledTimes(1)
@@ -252,7 +305,8 @@ describe('Expired domains test suites', () => {
 
     await expect(
       testMarshall.validate({
-        packageName: packageData([{ name: 'maintainer', email: 'dev@service.unknown' }])
+        packageName: packageData([{ name: 'maintainer', email: 'dev@service.unknown' }]),
+        packageVersion: 'latest'
       })
     ).rejects.toThrow(NotEvaluated)
     expect(resolve.mock.calls).toEqual([
@@ -267,7 +321,8 @@ describe('Expired domains test suites', () => {
     const testMarshall = createMarshall({ resolve })
 
     await testMarshall.validate({
-      packageName: packageData([{ name: 'maintainer', email: 'dev@BÜCHER.DE.' }])
+      packageName: packageData([{ name: 'maintainer', email: 'dev@BÜCHER.DE.' }]),
+      packageVersion: 'latest'
     })
 
     expect(resolve).toHaveBeenCalledWith('xn--bcher-kva.de', 'NS')
@@ -281,9 +336,9 @@ describe('Expired domains test suites', () => {
       _registry: 'https://registry.example.test/'
     }
 
-    await expect(testMarshall.validate({ packageName: data })).resolves.toEqual([
-      ['ns1.example.com']
-    ])
+    await expect(
+      testMarshall.validate({ packageName: data, packageVersion: 'latest' })
+    ).resolves.toEqual([['ns1.example.com']])
     expect(resolve).toHaveBeenCalledWith('mail.public-domain.com', 'NS')
   })
 
@@ -295,7 +350,9 @@ describe('Expired domains test suites', () => {
       _registry: 'https://registry.example.test/'
     }
 
-    await expect(testMarshall.validate({ packageName: data })).rejects.toThrow(NotEvaluated)
+    await expect(
+      testMarshall.validate({ packageName: data, packageVersion: 'latest' })
+    ).rejects.toThrow(NotEvaluated)
     expect(resolve).not.toHaveBeenCalled()
   })
 
@@ -308,7 +365,8 @@ describe('Expired domains test suites', () => {
         packageName: packageData([
           { name: 'first', email: 'first@Public-Domain.COM' },
           { name: 'second', email: 'second@public-domain.com' }
-        ])
+        ]),
+        packageVersion: 'latest'
       })
     ).resolves.toEqual([['ns1.example.com']])
     expect(resolve).toHaveBeenCalledTimes(1)
@@ -324,7 +382,8 @@ describe('Expired domains test suites', () => {
         packageName: packageData([
           { name: 'first', email: 'first@public-domain.com' },
           { name: 'second', email: 'second@public-domain.com' }
-        ])
+        ]),
+        packageVersion: 'latest'
       })
     ).rejects.toThrow(
       '2 maintainer records could not be evaluated because DNS, RDAP, or email data was incomplete'
@@ -341,7 +400,8 @@ describe('Expired domains test suites', () => {
         packageName: packageData([
           { name: 'first', email: 'first@public-domain.com' },
           { name: 'second', email: 'second@public-domain.org' }
-        ])
+        ]),
+        packageVersion: 'latest'
       })
     ).resolves.toEqual([['ns1.example.com'], ['ns1.example.com']])
     expect(resolve).toHaveBeenCalledTimes(2)

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,7 +88,9 @@ When adding new features or making significant changes:
 ## Design specifications
 
 - [Custom registry support](./superpowers/specs/2026-07-11-custom-registry-support-design.md) - approved design for npm-compatible Artifactory and private registry support.
+- [Expired-domain resolved version](./superpowers/specs/2026-07-17-expired-domain-resolved-version-design.md) - design for resolving the exact dependency version for expired-domain checks.
 
 ## Implementation plans
 
 - [Custom registry support](./superpowers/plans/2026-07-11-custom-registry-support.md) - task-by-task implementation plan for issue #429.
+- [Expired-domain resolved version](./superpowers/plans/2026-07-17-expired-domain-resolved-version.md) - implementation plan for exact dependency-version resolution in expired-domain checks.

--- a/docs/superpowers/plans/2026-07-17-expired-domain-resolved-version.md
+++ b/docs/superpowers/plans/2026-07-17-expired-domain-resolved-version.md
@@ -66,7 +66,7 @@ Expected: FAIL because the current implementation resolves `dist-tags.latest` an
 
 Ensure existing direct calls to `validate` specify `packageVersion: 'latest'` where their fixture represents the latest release. This makes the selector contract explicit without changing each test's DNS/RDAP assertion.
 
-- [ ] **Step 4: Commit the red test state only if it is useful to preserve**
+- [ ] **Step 4: Do not commit the red test state**
 
 Do not commit a deliberately failing state unless a separate review checkpoint requires it. Continue directly to the minimal implementation after recording the expected failure output.
 

--- a/docs/superpowers/plans/2026-07-17-expired-domain-resolved-version.md
+++ b/docs/superpowers/plans/2026-07-17-expired-domain-resolved-version.md
@@ -1,0 +1,149 @@
+# Expired-Domain Requested-Version Resolution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make expired-domain checks inspect maintainers from the package version npq will install instead of from the `latest` dist-tag.
+
+**Architecture:** `ExpiredDomainsMarshall` will resolve the package selector against the pakument it already fetched through `BaseMarshall.resolvePackageVersion`. It will then select only that version's maintainer list, leaving the existing normalization, DNS, RDAP, warning, and `NotEvaluated` logic intact.
+
+**Tech Stack:** Node.js 24, Jest 30, semver, Changesets.
+
+## Global Constraints
+
+- Base the implementation on `origin/main` through branch `work/fix-expired-domain-resolved-version`.
+- Do not add registry, DNS, RDAP, or dependency requests beyond the existing marshall behavior.
+- Preserve current warning-only account-takeover findings and `NotEvaluated` handling.
+- Add a patch changeset for this user-visible correctness fix.
+- Run `npm test`, `npm run lint`, and `npm run build` before handoff.
+
+---
+
+### Task 1: Capture requested-version regressions
+
+**Files:**
+- Modify: `__tests__/marshalls.expiredDomains.test.js`
+
+**Interfaces:**
+- Consumes: `ExpiredDomainsMarshall.validate({ packageName, packageVersion })`.
+- Produces: regression coverage for exact versions, semver ranges, dist-tags, and unresolved selectors.
+
+- [ ] **Step 1: Write failing tests**
+
+Add a pakument fixture with maintainer domains that differ by version and a table-driven test that supplies the selector and expected domain:
+
+```js
+test.each([
+  ['an exact older version', '1.0.0', 'exact.example.com'],
+  ['a semver range', '^1.0.0', 'range.example.com'],
+  ['a non-latest dist-tag', 'next', 'next.example.com']
+])('checks maintainers for %s', async (_case, packageVersion, expectedDomain) => {
+  const resolve = jest.fn().mockResolvedValue(['ns1.example.com'])
+  const testMarshall = createMarshall({ resolve })
+
+  await testMarshall.validate({ packageName: pakumentWithVersionedMaintainers, packageVersion })
+
+  expect(resolve).toHaveBeenCalledWith(expectedDomain, 'NS')
+  expect(resolve).not.toHaveBeenCalledWith('latest.example.com', 'NS')
+})
+```
+
+Add an unresolvable-selector test that expects `NotEvaluated` and no DNS lookup:
+
+```js
+await expect(
+  testMarshall.validate({ packageName: pakumentWithVersionedMaintainers, packageVersion: 'unknown' })
+).rejects.toThrow(NotEvaluated)
+expect(resolve).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 2: Run the expired-domain test file to verify red**
+
+Run: `npm test -- __tests__/marshalls.expiredDomains.test.js`
+
+Expected: FAIL because the current implementation resolves `dist-tags.latest` and queries `latest.example.com` for every selector.
+
+- [ ] **Step 3: Adapt existing test request fixtures**
+
+Ensure existing direct calls to `validate` specify `packageVersion: 'latest'` where their fixture represents the latest release. This makes the selector contract explicit without changing each test's DNS/RDAP assertion.
+
+- [ ] **Step 4: Commit the red test state only if it is useful to preserve**
+
+Do not commit a deliberately failing state unless a separate review checkpoint requires it. Continue directly to the minimal implementation after recording the expected failure output.
+
+### Task 2: Select maintainers from the resolved release
+
+**Files:**
+- Modify: `lib/marshalls/expiredDomains.marshall.js`
+- Test: `__tests__/marshalls.expiredDomains.test.js`
+
+**Interfaces:**
+- Consumes: `this.resolvePackageVersion(packageName, versionSpec, pakument)` returning an exact version string or `null`.
+- Produces: `maintainersAccounts` drawn only from `pakument.versions[resolvedVersion]`.
+
+- [ ] **Step 1: Write the minimal implementation**
+
+Replace the direct `latest` lookup at the start of `validate` with:
+
+```js
+const packageVersion = await this.resolvePackageVersion(
+  pkg.packageName,
+  pkg.packageVersion || 'latest',
+  data
+)
+const versionData = packageVersion && data.versions && data.versions[packageVersion]
+const maintainersAccounts = versionData && versionData.maintainers
+```
+
+Keep the existing `NotEvaluated` check immediately after this block. It handles both a `null` resolution and an absent maintainer list without a pass or a warning.
+
+- [ ] **Step 2: Run the expired-domain test file to verify green**
+
+Run: `npm test -- __tests__/marshalls.expiredDomains.test.js`
+
+Expected: PASS, including the exact-version, range, dist-tag, and unresolvable-selector regressions.
+
+- [ ] **Step 3: Run the complete test suite**
+
+Run: `npm test`
+
+Expected: all suites pass with no coverage regression below configured thresholds.
+
+### Task 3: Document the patch release
+
+**Files:**
+- Create: `.changeset/resolved-expired-domain-version.md`
+
+**Interfaces:**
+- Produces: a patch release note for package `npq`.
+
+- [ ] **Step 1: Add the changeset**
+
+Create a patch changeset with this content:
+
+```md
+---
+'npq': patch
+---
+
+Check expired-domain risk using maintainers from the package version being installed instead of always using the latest release.
+```
+
+- [ ] **Step 2: Run final static and build verification**
+
+Run: `npm run lint`
+
+Expected: exit 0; existing warnings may remain unchanged.
+
+Run: `npm run build`
+
+Expected: exit 0.
+
+- [ ] **Step 3: Review the final diff and commit**
+
+Run: `git diff --check` and `git status --short`.
+
+Stage only the marshall, tests, changeset, design, and plan documents. Commit with:
+
+```bash
+git commit -m "fix: inspect resolved version for expired domains"
+```

--- a/docs/superpowers/specs/2026-07-17-expired-domain-resolved-version-design.md
+++ b/docs/superpowers/specs/2026-07-17-expired-domain-resolved-version-design.md
@@ -1,0 +1,31 @@
+# Expired-Domain Requested-Version Resolution
+
+## Goal
+
+Make the expired-domain marshall inspect the maintainer metadata for the package version npq will install, rather than always inspecting the `latest` dist-tag.
+
+## Scope
+
+- Resolve `pkg.packageVersion` against the pakument already fetched for the package.
+- Read maintainers only from `pakument.versions[resolvedVersion]`.
+- Treat an unresolvable requested version or missing maintainers for that resolved version as `NotEvaluated`.
+- Preserve the existing domain normalization, DNS classification, RDAP corroboration, warning semantics, and custom-registry behavior.
+- Add regression tests for an exact older version, a semver range, and a non-`latest` dist-tag.
+- Add a patch changeset describing the corrected evaluation target.
+
+## Design
+
+`ExpiredDomainsMarshall.validate(pkg)` already fetches the pakument. It will call the inherited `resolvePackageVersion(pkg.packageName, pkg.packageVersion, pakument)` helper with that same object, avoiding a second registry request. The marshall will select `pakument.versions[resolvedVersion]` only after resolution succeeds.
+
+When resolution returns `null`, or when the selected version has no maintainer list, validation will throw `NotEvaluated`. This preserves the current conservative policy: no missing or ambiguous metadata is represented as a pass or as an account-takeover warning.
+
+## Testing
+
+Each regression fixture will deliberately give `latest` different maintainer data from the requested version. The tests will assert the DNS resolver receives only the requested version's normalized email domain. They will cover an exact version, `^1.0.0`, and a `next` dist-tag. Existing tests continue to cover DNS, RDAP, malformed metadata, and unavailable maintainer data.
+
+## Non-goals
+
+- Changing warning text to list maintainer names or email addresses.
+- Changing the DNS or RDAP evidence model.
+- Changing package-version resolution shared by other marshalls.
+- Adding new network requests or dependencies.

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -30,10 +30,14 @@ class Marshall extends BaseMarshall {
 
   async validate(pkg) {
     const data = await this.packageRepoUtils.getPackageInfo(pkg.packageName)
-    const lastVersionData =
-      data.versions && data['dist-tags'] && data.versions[data['dist-tags'].latest]
+    const packageVersion = await this.resolvePackageVersion(
+      pkg.packageName,
+      pkg.packageVersion || 'latest',
+      data
+    )
+    const versionData = packageVersion && data.versions && data.versions[packageVersion]
 
-    const maintainersAccounts = lastVersionData && lastVersionData.maintainers
+    const maintainersAccounts = versionData && versionData.maintainers
 
     if (!Array.isArray(maintainersAccounts) || maintainersAccounts.length === 0) {
       throw new NotEvaluated('no maintainers information available for the package')


### PR DESCRIPTION
## Summary

- resolve the requested package selector against the already-fetched pakument before checking expired-domain maintainers
- evaluate maintainers from the exact installed version rather than always from `latest`
- add regression coverage for exact versions, semver ranges, dist-tags, and unresolved selectors

## Why

The expired-domain marshall previously inspected `dist-tags.latest` even when npq was about to install a different version. That could produce findings for a release other than the one being installed.

## Validation

- `npm test` — 37 suites, 581 tests passed
- `npm run lint` — passed with 20 pre-existing warnings and no errors
- `npm run build` — passed
- `git diff --check` — passed

## Release

Includes a patch changeset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix expired-domain checks to use maintainers from the exact version that will be installed, not always `latest`, so findings match the selected release. Unresolvable selectors now skip evaluation as NotEvaluated.

- **Bug Fixes**
  - Resolve the requested selector via `resolvePackageVersion` and read maintainers from `versions[<resolved>]`.
  - Preserve warning semantics; treat missing maintainers or unresolved selectors as `NotEvaluated`.
  - Add regression tests for exact versions, semver ranges, and non-`latest` dist-tags; update docs with the design, implementation plan, and clarified red-test commit guidance; include a patch changeset for `npq`.

<sup>Written for commit 2400f84d0ccb0260006fba04778ac287ea424b98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

