### PR TITLE
fix: identify maintainers in expired-domain warnings 🤖🤖🤖

### DIFF
--- a/.changeset/clear-maintainer-identities.md
+++ b/.changeset/clear-maintainer-identities.md
@@ -2,4 +2,4 @@
 "npq": patch
 ---
 
-Show the maintainers affected by corroborated expired-domain warnings.
+Show the maintainers affected by corroborated expired-domain warnings and strip terminal control characters from their displayed identities.

--- a/.changeset/clear-maintainer-identities.md
+++ b/.changeset/clear-maintainer-identities.md
@@ -1,0 +1,5 @@
+---
+"npq": patch
+---
+
+Show the maintainers affected by corroborated expired-domain warnings.

--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -138,7 +138,7 @@ describe('Expired domains test suites', () => {
       expect.objectContaining({
         constructor: Warning,
         message:
-          'Maintainer domain missing-domain.com does not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.'
+          'Maintainer domain missing-domain.com does not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.\n\nAffected maintainers:\n- missing-domain.com: maintainer <dev@missing-domain.com>'
       })
     )
   })
@@ -212,9 +212,41 @@ describe('Expired domains test suites', () => {
         packageVersion: 'latest'
       })
     ).rejects.toThrow(
-      'Maintainer domains a-domain.com, b-domain.com do not resolve in public DNS, and RDAP found no active registration; account takeover may be possible. 2 other maintainer records could not be evaluated.'
+      'Maintainer domains a-domain.com, b-domain.com do not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.\n\nAffected maintainers:\n- a-domain.com: a <dev@a-domain.com>\n- b-domain.com: b <dev@b-domain.com>\n\n2 other maintainer records could not be evaluated.'
     )
     expect(resolve).toHaveBeenCalledWith('com', 'NS')
+  })
+
+  test('identifies maintainers affected by corroborated domains', async () => {
+    const resolve = jest.fn(async (domain) => {
+      if (domain === 'a-domain.com' || domain === 'b-domain.com') {
+        throw dnsFailure('ENOTFOUND', domain)
+      }
+      if (domain === 'timeout-domain.com') {
+        throw dnsFailure('ETIMEOUT', domain)
+      }
+      if (domain === 'com') {
+        return ['a.gtld-servers.net']
+      }
+      return ['ns1.example.com']
+    })
+    const testMarshall = createMarshall({ resolve })
+
+    await expect(
+      testMarshall.validate({
+        packageName: packageData([
+          { name: 'B first', email: 'first@b-domain.com' },
+          { name: 'invalid', email: '' },
+          { name: 'timeout', email: 'timeout@timeout-domain.com' },
+          { name: 'A', email: 'a@a-domain.com' },
+          { name: 'B second', email: 'second@b-domain.com' },
+          { email: 'nameless@a-domain.com' }
+        ]),
+        packageVersion: 'latest'
+      })
+    ).rejects.toThrow(
+      'Maintainer domains a-domain.com, b-domain.com do not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.\n\nAffected maintainers:\n- a-domain.com: A <a@a-domain.com>, nameless@a-domain.com\n- b-domain.com: B first <first@b-domain.com>, B second <second@b-domain.com>\n\n2 other maintainer records could not be evaluated.'
+    )
   })
 
   test('suppresses a DNS warning when RDAP finds a registered domain', async () => {

--- a/__tests__/marshalls.expiredDomains.test.js
+++ b/__tests__/marshalls.expiredDomains.test.js
@@ -249,6 +249,30 @@ describe('Expired domains test suites', () => {
     )
   })
 
+  test('removes terminal control characters from maintainer identities', async () => {
+    const resolve = jest.fn(async (domain) => {
+      if (domain === 'com') {
+        return ['a.gtld-servers.net']
+      }
+      throw dnsFailure('ENOTFOUND', domain)
+    })
+    const testMarshall = createMarshall({ resolve })
+
+    await expect(
+      testMarshall.validate({
+        packageName: packageData([
+          {
+            name: 'Trusted\nMaintainer\u001b[31m',
+            email: 'dev\u001b[0m@missing-domain.com'
+          }
+        ]),
+        packageVersion: 'latest'
+      })
+    ).rejects.toThrow(
+      'Maintainer domain missing-domain.com does not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.\n\nAffected maintainers:\n- missing-domain.com: TrustedMaintainer[31m <dev[0m@missing-domain.com>'
+    )
+  })
+
   test('suppresses a DNS warning when RDAP finds a registered domain', async () => {
     const resolve = jest.fn(async (domain) => {
       if (domain === 'com') {

--- a/docs/README.md
+++ b/docs/README.md
@@ -88,6 +88,7 @@ When adding new features or making significant changes:
 ## Design specifications
 
 - [Custom registry support](./superpowers/specs/2026-07-11-custom-registry-support-design.md) - approved design for npm-compatible Artifactory and private registry support.
+- [Expired-domain maintainer identity warnings](./superpowers/specs/2026-07-17-expired-domain-maintainer-identities-design.md) - approved design for attributable expired-domain warnings.
 - [Expired-domain resolved version](./superpowers/specs/2026-07-17-expired-domain-resolved-version-design.md) - design for resolving the exact dependency version for expired-domain checks.
 
 ## Implementation plans

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,3 +95,4 @@ When adding new features or making significant changes:
 
 - [Custom registry support](./superpowers/plans/2026-07-11-custom-registry-support.md) - task-by-task implementation plan for issue #429.
 - [Expired-domain resolved version](./superpowers/plans/2026-07-17-expired-domain-resolved-version.md) - implementation plan for exact dependency-version resolution in expired-domain checks.
+- [Expired-domain maintainer identity warnings](./superpowers/plans/2026-07-17-expired-domain-maintainer-identities.md) - test-first implementation plan for attributable expired-domain warnings.

--- a/docs/feature/expired-domains.md
+++ b/docs/feature/expired-domains.md
@@ -19,6 +19,10 @@ Maintainer email hosts are converted to ASCII, lowercased, and checked as comple
 
 A warning remains non-blocking. RDAP absence is not proof of current purchasability, registry policy can prevent registration, and npm account two-factor authentication status is not known to this check.
 
+## Warning attribution
+
+When DNS and RDAP corroborate an expired-domain warning, NPQ lists the affected maintainers grouped beneath each domain. The local warning includes the registry name and email when a name is available, or the email alone when it is not. This makes the finding traceable during a security review.
+
 ## External requests and privacy
 
 The marshall sends normalized host or domain names only, never full maintainer email addresses.

--- a/docs/feature/expired-domains.md
+++ b/docs/feature/expired-domains.md
@@ -21,7 +21,7 @@ A warning remains non-blocking. RDAP absence is not proof of current purchasabil
 
 ## Warning attribution
 
-When DNS and RDAP corroborate an expired-domain warning, NPQ lists the affected maintainers grouped beneath each domain. The local warning includes the registry name and email when a name is available, or the email alone when it is not. This makes the finding traceable during a security review.
+When DNS and RDAP corroborate an expired-domain warning, NPQ lists the affected maintainers grouped beneath each domain. The local warning includes the registry name and email when a name is available, or the email alone when it is not. This makes the finding traceable during a security review. Control characters are stripped from the displayed identities.
 
 ## External requests and privacy
 

--- a/docs/superpowers/plans/2026-07-17-expired-domain-maintainer-identities.md
+++ b/docs/superpowers/plans/2026-07-17-expired-domain-maintainer-identities.md
@@ -1,0 +1,202 @@
+# Expired-Domain Maintainer Identity Warnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Include the individual maintainers affected by each corroborated expired-domain warning.
+
+**Architecture:** `ExpiredDomainsMarshall` will keep valid registry maintainer records in a second map keyed by the existing normalized email domain. The current deduplicated DNS, public-TLD, and RDAP flow will select corroborated domains as it does today, then format only those domains and their mapped maintainers into the local `Warning` message.
+
+**Tech Stack:** Node.js 24, Jest 30, Changesets.
+
+## Global Constraints
+
+- Work only from branch `work/improve-expired-domain-warning` based on merged `origin/main` commit `ff70907`.
+- Preserve the current package-version resolution, DNS classification, public-TLD validation, RDAP lookup, warning eligibility, and incomplete-record count.
+- Output identities only in the local warning. DNS and RDAP requests must continue to receive normalized domains only.
+- List corroborated domains in lexical order and maintainer records in their original registry order.
+- Render a non-empty name as `name <email>` and a missing or blank name as `email`.
+- Add a patch changeset and run `npm test`, `npm run lint`, and `npm run build` before handoff.
+
+---
+
+### Task 1: Capture attributable warning output
+
+**Files:**
+- Modify: `__tests__/marshalls.expiredDomains.test.js:189-218`
+
+**Interfaces:**
+- Consumes: `ExpiredDomainsMarshall.validate({ packageName, packageVersion })`.
+- Produces: a regression assertion for grouped identities, lexical domain order, registry identity order, name fallback, and the existing incomplete-record suffix.
+
+- [ ] **Step 1: Write the failing regression expectation**
+
+Replace the current `orders suspected domains and reports other incomplete records` fixture with this maintainer list, preserving the existing DNS mock and `latest` selector:
+
+```js
+packageData([
+  { name: "B first", email: "first@b-domain.com" },
+  { name: "invalid", email: "" },
+  { name: "timeout", email: "timeout@timeout-domain.com" },
+  { name: "A", email: "a@a-domain.com" },
+  { name: "B second", email: "second@b-domain.com" },
+  { email: "nameless@a-domain.com" }
+])
+```
+
+Replace the expected warning string with:
+
+```text
+Maintainer domains a-domain.com, b-domain.com do not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.
+
+Affected maintainers:
+- a-domain.com: A <a@a-domain.com>, nameless@a-domain.com
+- b-domain.com: B first <first@b-domain.com>, B second <second@b-domain.com>
+
+2 other maintainer records could not be evaluated.
+```
+
+Keep `expect(resolve).toHaveBeenCalledWith("com", "NS")` so the test also protects the existing public-TLD check.
+
+- [ ] **Step 2: Run the focused test to verify it is red**
+
+Run: `npm test -- __tests__/marshalls.expiredDomains.test.js`
+
+Expected: FAIL because the current warning contains only the corroborated domain summary and the incomplete-record suffix.
+
+- [ ] **Step 3: Do not commit the red test state**
+
+Leave the focused test failure uncommitted. Proceed directly to the minimal production implementation.
+
+### Task 2: Map maintainers to corroborated domains
+
+**Files:**
+- Modify: `lib/marshalls/expiredDomains.marshall.js:46-57`
+- Modify: `lib/marshalls/expiredDomains.marshall.js:141-151`
+- Test: `__tests__/marshalls.expiredDomains.test.js:189-218`
+
+**Interfaces:**
+- Consumes: valid maintainer records and `normalizeMaintainerDomain(maintainerInfo.email)`.
+- Produces: `maintainersByDomain`, a `Map<string, Array<{name?: string, email: string}>>`, used only while formatting `Warning` output.
+
+- [ ] **Step 1: Keep valid maintainer records by normalized domain**
+
+Alongside the existing `emailDomains` map, initialize and populate a maintainer-record map after the existing valid-email check:
+
+```js
+const emailDomains = new Map()
+const maintainersByDomain = new Map()
+let invalidMaintainers = 0
+
+for (const maintainerInfo of maintainersAccounts) {
+  const emailDomain = normalizeMaintainerDomain(maintainerInfo && maintainerInfo.email)
+
+  if (!emailDomain) {
+    invalidMaintainers += 1
+    continue
+  }
+
+  emailDomains.set(emailDomain, (emailDomains.get(emailDomain) || 0) + 1)
+  const domainMaintainers = maintainersByDomain.get(emailDomain) || []
+  domainMaintainers.push(maintainerInfo)
+  maintainersByDomain.set(emailDomain, domainMaintainers)
+}
+```
+
+Do not change the `emailDomains` values or any DNS/RDAP input arrays. They continue to own deduplication and incomplete-record arithmetic.
+
+- [ ] **Step 2: Format identities after the existing warning summary**
+
+Before appending the existing incomplete-record suffix, append an identity section for `corroboratedDomains`:
+
+```js
+const affectedMaintainers = corroboratedDomains
+  .map((domain) => {
+    const identities = maintainersByDomain
+      .get(domain)
+      .map((maintainer) => {
+        const name = typeof maintainer.name === "string" ? maintainer.name.trim() : ""
+        return name.length > 0 ? `${name} <${maintainer.email}>` : maintainer.email
+      })
+      .join(", ")
+
+    return `- ${domain}: ${identities}`
+  })
+  .join("\n")
+
+message += `\n\nAffected maintainers:\n${affectedMaintainers}`
+```
+
+Place this block after the existing summary assignment and before `if (incompleteCount > 0)`. `corroboratedDomains` is already ordered by the sorted input domain list, and the new map preserves each domain list insertion order.
+
+- [ ] **Step 3: Run the focused test to verify it is green**
+
+Run: `npm test -- __tests__/marshalls.expiredDomains.test.js`
+
+Expected: PASS. The assertion proves identity grouping, both ordering guarantees, blank-name fallback, and preserved incomplete-record wording.
+
+- [ ] **Step 4: Run the complete test suite**
+
+Run: `npm test`
+
+Expected: all suites pass with no newly failing tests.
+
+### Task 3: Document and release the user-visible warning change
+
+**Files:**
+- Modify: `docs/feature/expired-domains.md:22-28`
+- Modify: `docs/README.md:88-96`
+- Create: `.changeset/clear-maintainer-identities.md`
+- Create: `docs/superpowers/plans/2026-07-17-expired-domain-maintainer-identities.md`
+
+**Interfaces:**
+- Produces: user-facing documentation that identifies the local-only identity output and a patch release note for package `npq`.
+
+- [ ] **Step 1: Document warning attribution**
+
+Add a `## Warning attribution` section before `## External requests and privacy` in `docs/feature/expired-domains.md`:
+
+```md
+## Warning attribution
+
+When DNS and RDAP corroborate an expired-domain warning, NPQ lists the affected maintainers grouped beneath each domain. The local warning includes the registry name and email when a name is available, or the email alone when it is not. This makes the finding traceable during a security review.
+```
+
+In `docs/README.md`, add the plan entry below the existing expired-domain resolved-version plan:
+
+```md
+- [Expired-domain maintainer identity warnings](./superpowers/plans/2026-07-17-expired-domain-maintainer-identities.md) - test-first implementation plan for attributable expired-domain warnings.
+```
+
+- [ ] **Step 2: Add the patch changeset**
+
+Create `.changeset/clear-maintainer-identities.md` with:
+
+```md
+---
+"npq": patch
+---
+
+Show the maintainers affected by corroborated expired-domain warnings.
+```
+
+- [ ] **Step 3: Run final verification**
+
+Run: `npm run lint`
+
+Expected: exit 0. Existing warnings may remain unchanged.
+
+Run: `npm run build`
+
+Expected: exit 0.
+
+Run: `git diff --check`
+
+Expected: no whitespace errors.
+
+- [ ] **Step 4: Commit the implementation**
+
+Stage only `lib/marshalls/expiredDomains.marshall.js`, `__tests__/marshalls.expiredDomains.test.js`, `docs/feature/expired-domains.md`, `docs/README.md`, `.changeset/clear-maintainer-identities.md`, and this plan. Commit with:
+
+```bash
+git commit -m "fix: identify maintainers in expired-domain warnings"
+```

--- a/docs/superpowers/specs/2026-07-17-expired-domain-maintainer-identities-design.md
+++ b/docs/superpowers/specs/2026-07-17-expired-domain-maintainer-identities-design.md
@@ -1,0 +1,59 @@
+# Expired-domain maintainer identity warning design
+
+## Goal
+
+Make a corroborated expired-domain warning attributable by listing the package
+maintainer records that use each affected email domain. This supports the NPQ
+security-audit and provenance use case without changing the evidence threshold
+for a warning.
+
+## Scope
+
+The expired-domain marshall will retain the normalized maintainer records for
+each normalized email domain while it evaluates DNS and RDAP evidence. When a
+domain is corroborated as unregistered, the warning will keep its existing
+summary sentence and append an `Affected maintainers:` section. Each affected
+domain is listed in lexical order, followed by the maintainer identities in
+their registry order as `name <email>`.
+
+For example:
+
+```text
+Maintainer domain example.com does not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.
+
+Affected maintainers:
+- example.com: Alice Smith <alice@example.com>, Bob Jones <bob@example.com>
+```
+
+A maintainer with a non-empty name is rendered as `name <email>`; a maintainer
+without a usable name is rendered as `email` alone. Invalid email records remain
+excluded from the identity list and continue to be counted as incomplete records
+under the current policy.
+
+## Non-goals
+
+- Do not change package-version resolution, DNS classification, public-TLD
+  validation, RDAP lookup, or warning eligibility.
+- Do not disclose maintainer identities to DNS or RDAP services; external
+  requests continue to use normalized domains only.
+- Do not add CLI configuration, debug-only output, or a new warning class.
+
+## Data flow
+
+1. Validate each maintainer email using the existing normalizer.
+2. Store each valid original maintainer record under its normalized domain while
+   preserving the existing per-domain count for incomplete-record reporting.
+3. Run the existing deduplicated DNS, public-TLD, and RDAP pipeline against
+   normalized domains.
+4. When RDAP corroborates a domain, format the associated identities into the
+   warning after the established summary sentence.
+5. Keep the existing incomplete-record suffix unchanged.
+
+## Testing
+
+Add regression tests that prove a warning includes identities for multiple
+maintainers sharing one corroborated domain, groups identities by multiple
+domains in deterministic domain order, preserves their original maintainer
+order within a group, and leaves the incomplete-record suffix intact. Existing
+DNS/RDAP and version-resolution tests remain the safety net for unchanged
+policy.

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -44,6 +44,7 @@ class Marshall extends BaseMarshall {
     }
 
     const emailDomains = new Map()
+    const maintainersByDomain = new Map()
     let invalidMaintainers = 0
     for (const maintainerInfo of maintainersAccounts) {
       const emailDomain = normalizeMaintainerDomain(maintainerInfo && maintainerInfo.email)
@@ -54,6 +55,9 @@ class Marshall extends BaseMarshall {
       }
 
       emailDomains.set(emailDomain, (emailDomains.get(emailDomain) || 0) + 1)
+      const domainMaintainers = maintainersByDomain.get(emailDomain) || []
+      domainMaintainers.push(maintainerInfo)
+      maintainersByDomain.set(emailDomain, domainMaintainers)
     }
 
     if (emailDomains.size === 0) {
@@ -142,10 +146,25 @@ class Marshall extends BaseMarshall {
       const domainNoun = corroboratedDomains.length === 1 ? 'domain' : 'domains'
       const resolveVerb = corroboratedDomains.length === 1 ? 'does' : 'do'
       let message = `Maintainer ${domainNoun} ${corroboratedDomains.join(', ')} ${resolveVerb} not resolve in public DNS, and RDAP found no active registration; account takeover may be possible.`
+      const affectedMaintainers = corroboratedDomains
+        .map((domain) => {
+          const identities = maintainersByDomain
+            .get(domain)
+            .map((maintainer) => {
+              const name = typeof maintainer.name === 'string' ? maintainer.name.trim() : ''
+              return name.length > 0 ? `${name} <${maintainer.email}>` : maintainer.email
+            })
+            .join(', ')
+
+          return `- ${domain}: ${identities}`
+        })
+        .join('\n')
+
+      message += `\n\nAffected maintainers:\n${affectedMaintainers}`
 
       if (incompleteCount > 0) {
         const recordNoun = incompleteCount === 1 ? 'record' : 'records'
-        message += ` ${incompleteCount} other maintainer ${recordNoun} could not be evaluated.`
+        message += `\n\n${incompleteCount} other maintainer ${recordNoun} could not be evaluated.`
       }
 
       throw new Warning(message)

--- a/lib/marshalls/expiredDomains.marshall.js
+++ b/lib/marshalls/expiredDomains.marshall.js
@@ -15,6 +15,19 @@ const dns = new Resolver()
 dns.setServers(['1.1.1.1', '8.8.8.8'])
 const MARSHALL_NAME = 'maintainers_expired_emails'
 
+function stripTerminalControlCharacters(value) {
+  if (typeof value !== 'string') {
+    return ''
+  }
+
+  return [...value]
+    .filter((character) => {
+      const codePoint = character.codePointAt(0)
+      return codePoint >= 0x20 && (codePoint < 0x7f || codePoint > 0x9f)
+    })
+    .join('')
+}
+
 class Marshall extends BaseMarshall {
   constructor(options) {
     super(options)
@@ -151,8 +164,9 @@ class Marshall extends BaseMarshall {
           const identities = maintainersByDomain
             .get(domain)
             .map((maintainer) => {
-              const name = typeof maintainer.name === 'string' ? maintainer.name.trim() : ''
-              return name.length > 0 ? `${name} <${maintainer.email}>` : maintainer.email
+              const name = stripTerminalControlCharacters(maintainer.name).trim()
+              const email = stripTerminalControlCharacters(maintainer.email)
+              return name.length > 0 ? `${name} <${email}>` : email
             })
             .join(', ')
 


### PR DESCRIPTION
## Summary

- group corroborated expired domains with the maintainers using each domain
- show `name <email>` identities in the local warning, with email-only fallback
- retain the current DNS/RDAP evidence policy and incomplete-record reporting

## Why

This follow-up to #447 makes a corroborated account-takeover signal traceable during a security audit.

## Validation

- `npm test`
- `npm run lint` (passes with 20 pre-existing warnings in unrelated files)
- `npm run build`
- independent whole-branch review: no findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds maintainer attribution to expired-domain warnings and sanitizes identities so audits can trace who is affected without leaking data. The warning now groups maintainers by corroborated domain while keeping the DNS/RDAP policy unchanged.

- **New Features**
  - Adds an "Affected maintainers" section per corroborated domain, formatting as `name <email>` with email-only fallback; domains are sorted and maintainers keep registry order. Preserves DNS/RDAP policy and the incomplete-record suffix; identities are not sent to external services.
  - Updates tests and docs; includes a patch changeset for `npq`.

- **Bug Fixes**
  - Strips terminal control characters from maintainer names and emails in warnings; adds tests for sanitization.

<sup>Written for commit eed3f7fb6270b792a8372fab71e795c9cbdeb7ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/lirantal/npq/pull/448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

